### PR TITLE
Adding tests for rexec/server, minor msg format fix and doc updates

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -16,10 +16,9 @@ jobs:
     strategy:
       matrix:
         go-version: [ '1.25.x' ]
-
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -34,7 +33,7 @@ jobs:
         run: go test -json -v -race -count=1 ./... > TestResults-${{ matrix.go-version }}.json
 
       - name: Upload Go test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: Go-results-${{ matrix.go-version }}
           path: TestResults-${{ matrix.go-version }}.json

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,0 +1,40 @@
+name: Go tests
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.25.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Install dependencies
+        run: go get .
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -json -v -race -count=1 ./... > TestResults-${{ matrix.go-version }}.json
+
+      - name: Upload Go test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Go-results-${{ matrix.go-version }}
+          path: TestResults-${{ matrix.go-version }}.json

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ See the [Getting started](https://github.com/Adyen/kubectl-rexec/blob/master/STA
 ## Usage
 See the [Getting started](https://github.com/Adyen/kubectl-rexec/blob/master/STARTED.md) guide.
 
+## Testing
+Tests are currently implemented for the rexec/server
+
+Run the tests like:
+`go test ./rexec/server`
+
 ## Documentation
 See the [Design](https://github.com/Adyen/kubectl-rexec/blob/master/DESIGN.md).
 

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -46,7 +46,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	pod := pathParams["pod"]
 	user := r.Header.Get("X-Remote-User")
 
-	// if any of the mimimal parameters are missing we should bail
+	// if any of the minimal parameters are missing we should bail
 	if user == "" || namespace == "" || pod == "" {
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte(httpForbidden))
@@ -72,7 +72,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	// header which will end up in `admissionReview.Request.UserInfo.Extra`
 	r.Header.Add("Impersonate-Extra-Secret-Sauce", SecretSauce)
 
-	// template old and new url pathes and replace them in the url
+	// template old and new url paths and replace them in the url
 	newPath := fmt.Sprintf("api/v1/namespaces/%s/pods/%s/exec", namespace, pod)
 	oldPath := fmt.Sprintf("apis/audit.adyen.internal/v1beta1/namespaces/%s/pods/%s/exec", namespace, pod)
 	r.URL.Path = strings.ReplaceAll(r.URL.Path, oldPath, newPath)
@@ -86,7 +86,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// first fetching the command parameters from the url params to check what commands were passed
+	// first fetch the command parameters from the url params to check what commands were passed
 	// initially to the container
 	var initialCommand []string
 	needsRecording := false
@@ -94,7 +94,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 		if key == "command" {
 			initialCommand = append(initialCommand, value...)
 		}
-		// we also check wether tty was requested, if so we will need to record the session
+		// we also check whether tty was requested, if so we will need to record the session
 		if key == "tty" {
 			needsRecording = true
 		}
@@ -122,7 +122,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 
 		proxy.ServeHTTP(w, r)
 	} else {
-		// in the case of recoding we will pass the request through a tcp proxy to make it easier
+		// in the case of recording we will pass the request through a tcp proxy to make it easier
 		// to actually monitor what is being typed in to the shell
 
 		// we begin to generate a uuid for the session and we set it as the id of a context
@@ -139,7 +139,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 		r.WithContext(ctx)
 
 		// Log initial command as an audit event
-		// with sessin id
+		// with session id
 		logCommand(strings.Join(initialCommand, " "), user, ctxid)
 
 		// we start up a tcp forwarder for the session
@@ -175,7 +175,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// execHandler is responsible auditing exec request and allowing
+// execHandler is responsible for auditing exec request and allowing
 // the ones coming through rexec api along with allowlisted users
 func execHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Type") != "application/json" {
@@ -216,8 +216,8 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(respBytes)
 }
 
-// waitForListener is simly check wether the personnal tcp
-// forwarder ready or not, if it is not there after 5 secs
+// waitForListener is checking whether the tcp forwarder
+// is ready or not, if it is not there after 5 secs
 // it bails
 func waitForListener(listener string) error {
 	// again, super lazy but it is fine for now
@@ -232,7 +232,7 @@ func waitForListener(listener string) error {
 	return errors.New("socket was not ready in time")
 }
 
-// canPass checks wether the exec request is allowed
+// canPass checks whether the exec request is allowed
 // or not
 func canPass(rv admissionv1.AdmissionReview) bool {
 	// check for users that have a bypass for validating
@@ -242,7 +242,7 @@ func canPass(rv admissionv1.AdmissionReview) bool {
 		}
 	}
 
-	// we will check for shared key so we can validate the request was
+	// we will check for a shared key so we can validate the request was
 	// coming through the rexec endpoint
 	sauce, ok := rv.Request.UserInfo.Extra["secret-sauce"]
 	if ok {

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -1,0 +1,1 @@
+package server

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -42,13 +42,8 @@ func postExecHandler(t *testing.T, ar admissionv1.AdmissionReview, contentType s
 
 // --- execHandler tests ---
 
-func TestExecHandler_RejectsNonJSON(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/validate-exec", bytes.NewReader([]byte("not json")))
-	req.Header.Set("Content-Type", "text/plain")
-	rr := httptest.NewRecorder()
-
-	execHandler(rr, req)
-
+func TestExecHandler_UnsupportedContentType(t *testing.T) {
+	rr, _ := postExecHandler(t, admissionv1.AdmissionReview{}, "text/plain")
 	if rr.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnsupportedMediaType)
 	}

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -42,14 +42,14 @@ func postExecHandler(t *testing.T, ar admissionv1.AdmissionReview, contentType s
 
 // --- execHandler tests ---
 
-func TestExecHandler_UnsupportedContentType(t *testing.T) {
+func TestExecHandlerUnsupportedContentType(t *testing.T) {
 	rr, _ := postExecHandler(t, admissionv1.AdmissionReview{}, "text/plain")
 	if rr.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnsupportedMediaType)
 	}
 }
 
-func TestExecHandler_BadJSON(t *testing.T) {
+func TestExecHandlerBadJSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/validate-exec", bytes.NewReader([]byte("{bad-json")))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestExecHandler_BadJSON(t *testing.T) {
 	}
 }
 
-func TestExecHandler_AllowsNonExecKinds(t *testing.T) {
+func TestExecHandlerAllowsNonExecKinds(t *testing.T) {
 	ar := admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
 			UID:  "123",
@@ -77,7 +77,7 @@ func TestExecHandler_AllowsNonExecKinds(t *testing.T) {
 	}
 }
 
-func TestExecHandler_PodExec_BypassedUser(t *testing.T) {
+func TestExecHandlerBypassedUser(t *testing.T) {
 	oldBypass := ByPassedUsers
 	t.Cleanup(func() { ByPassedUsers = oldBypass })
 
@@ -104,7 +104,7 @@ func TestExecHandler_PodExec_BypassedUser(t *testing.T) {
 	}
 }
 
-func TestExecHandler_PodExec_SecretSauce(t *testing.T) {
+func TestExecHandlerSecretSauce(t *testing.T) {
 	oldBypass := ByPassedUsers
 	oldSauce := SecretSauce
 	t.Cleanup(func() {
@@ -137,7 +137,7 @@ func TestExecHandler_PodExec_SecretSauce(t *testing.T) {
 	}
 }
 
-func TestExecHandler_PodExec_Denied(t *testing.T) {
+func TestExecHandlerExecDenied(t *testing.T) {
 	oldBypass := ByPassedUsers
 	oldSauce := SecretSauce
 	t.Cleanup(func() {
@@ -176,7 +176,7 @@ func TestExecHandler_PodExec_Denied(t *testing.T) {
 
 // --- canPass unit tests ---
 
-func TestCanPass_BypassUser(t *testing.T) {
+func TestCanPassBypassUser(t *testing.T) {
 	oldBypass := ByPassedUsers
 	t.Cleanup(func() { ByPassedUsers = oldBypass })
 
@@ -193,7 +193,7 @@ func TestCanPass_BypassUser(t *testing.T) {
 	}
 }
 
-func TestCanPass_SecretSauceMatch(t *testing.T) {
+func TestCanPassSecretSauceMatch(t *testing.T) {
 	oldBypass := ByPassedUsers
 	oldSauce := SecretSauce
 	t.Cleanup(func() {
@@ -218,7 +218,7 @@ func TestCanPass_SecretSauceMatch(t *testing.T) {
 	}
 }
 
-func TestCanPass_NoMatch(t *testing.T) {
+func TestCanPassNoMatch(t *testing.T) {
 	oldBypass := ByPassedUsers
 	oldSauce := SecretSauce
 	t.Cleanup(func() {
@@ -246,7 +246,7 @@ func TestCanPass_NoMatch(t *testing.T) {
 
 // --- waitForListener unit test ---
 
-func TestWaitForListener_Ready(t *testing.T) {
+func TestWaitForListenerReady(t *testing.T) {
 	// Save/restore shared map
 	oldProxyMap := proxyMap
 	t.Cleanup(func() { proxyMap = oldProxyMap })
@@ -269,7 +269,7 @@ func TestWaitForListener_Ready(t *testing.T) {
 
 // --- rexecHandler early validation test ---
 
-func TestRexecHandler_MissingUserIsForbidden(t *testing.T) {
+func TestRexecHandlerMissingUser(t *testing.T) {
 	// No X-Remote-User header
 	req := httptest.NewRequest(http.MethodGet,
 		"/apis/audit.adyen.internal/v1beta1/namespaces/ns/pods/pod/exec", nil)

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -1,1 +1,293 @@
 package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	admissionv1 "k8s.io/api/admission/v1"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// --- helpers ---
+
+func postExecHandler(t *testing.T, ar admissionv1.AdmissionReview, contentType string) (rr *httptest.ResponseRecorder, got admissionv1.AdmissionReview) {
+	t.Helper()
+
+	body, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/validate-exec", bytes.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	rr = httptest.NewRecorder()
+
+	execHandler(rr, req)
+
+	if rr.Code == http.StatusOK {
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal response: %v\nbody: %s", err, rr.Body.String())
+		}
+	}
+	return rr, got
+}
+
+// --- execHandler tests ---
+
+func TestExecHandler_RejectsNonJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/validate-exec", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "text/plain")
+	rr := httptest.NewRecorder()
+
+	execHandler(rr, req)
+
+	if rr.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestExecHandler_BadJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/validate-exec", bytes.NewReader([]byte("{bad-json")))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	execHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestExecHandler_AllowsNonExecKinds(t *testing.T) {
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:  "123",
+			Kind: metav1.GroupVersionKind{Kind: "Not-PodExecOptions"},
+		},
+	}
+	rr, parsed := postExecHandler(t, ar, "application/json")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if parsed.Response == nil || !parsed.Response.Allowed {
+		t.Fatalf("expected Allowed=true for non-PodExecOptions, got: %+v", parsed.Response)
+	}
+}
+
+func TestExecHandler_PodExec_BypassedUser(t *testing.T) {
+	oldBypass := ByPassedUsers
+	t.Cleanup(func() { ByPassedUsers = oldBypass })
+
+	ByPassedUsers = []string{"lauren"}
+
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: "u1",
+			Kind: metav1.GroupVersionKind{
+				Kind: "PodExecOptions",
+			},
+			UserInfo: authv1.UserInfo{
+				Username: "lauren",
+			},
+		},
+	}
+
+	rr, parsed := postExecHandler(t, ar, "application/json")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if parsed.Response == nil || !parsed.Response.Allowed {
+		t.Fatalf("expected Allowed=true via ByPassedUsers, got: %+v", parsed.Response)
+	}
+}
+
+func TestExecHandler_PodExec_SecretSauce(t *testing.T) {
+	oldBypass := ByPassedUsers
+	oldSauce := SecretSauce
+	t.Cleanup(func() {
+		ByPassedUsers = oldBypass
+		SecretSauce = oldSauce
+	})
+
+	ByPassedUsers = nil
+	SecretSauce = "the-right-sauce"
+
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:  "u2",
+			Kind: metav1.GroupVersionKind{Kind: "PodExecOptions"},
+			UserInfo: authv1.UserInfo{
+				Username: "lauren",
+				Extra: map[string]authv1.ExtraValue{
+					"secret-sauce": {"the-right-sauce"},
+				},
+			},
+		},
+	}
+
+	rr, parsed := postExecHandler(t, ar, "application/json")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if parsed.Response == nil || !parsed.Response.Allowed {
+		t.Fatalf("expected Allowed=true via secret-sauce, got: %+v", parsed.Response)
+	}
+}
+
+func TestExecHandler_PodExec_Denied(t *testing.T) {
+	oldBypass := ByPassedUsers
+	oldSauce := SecretSauce
+	t.Cleanup(func() {
+		ByPassedUsers = oldBypass
+		SecretSauce = oldSauce
+	})
+
+	ByPassedUsers = nil
+	SecretSauce = "the-right-sauce"
+
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID:  "u3",
+			Kind: metav1.GroupVersionKind{Kind: "PodExecOptions"},
+			UserInfo: authv1.UserInfo{
+				Username: "lauren",
+				// No matching secret-sauce
+				Extra: map[string]authv1.ExtraValue{
+					"secret-sauce": {"the-wrong-sauce"},
+				},
+			},
+		},
+	}
+
+	rr, parsed := postExecHandler(t, ar, "application/json")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if parsed.Response == nil || parsed.Response.Allowed {
+		t.Fatalf("expected Allowed=false, got: %+v", parsed.Response)
+	}
+	if parsed.Response.Result == nil || parsed.Response.Result.Message != "cannot use exec directly, use rexec plugin instead" {
+		t.Fatalf("unexpected denial message: %+v", parsed.Response.Result)
+	}
+}
+
+// --- canPass unit tests ---
+
+func TestCanPass_BypassUser(t *testing.T) {
+	oldBypass := ByPassedUsers
+	t.Cleanup(func() { ByPassedUsers = oldBypass })
+
+	ByPassedUsers = []string{"lauren"}
+
+	rv := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UserInfo: authv1.UserInfo{Username: "lauren"},
+		},
+	}
+
+	if !canPass(rv) {
+		t.Fatal("expected canPass true for bypassed user")
+	}
+}
+
+func TestCanPass_SecretSauceMatch(t *testing.T) {
+	oldBypass := ByPassedUsers
+	oldSauce := SecretSauce
+	t.Cleanup(func() {
+		ByPassedUsers = oldBypass
+		SecretSauce = oldSauce
+	})
+
+	ByPassedUsers = nil
+	SecretSauce = "the-right-sauce"
+
+	rv := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UserInfo: authv1.UserInfo{
+				Extra: map[string]authv1.ExtraValue{
+					"secret-sauce": {"the-right-sauce"},
+				},
+			},
+		},
+	}
+	if !canPass(rv) {
+		t.Fatal("expected canPass true when secret-sauce matches")
+	}
+}
+
+func TestCanPass_NoMatch(t *testing.T) {
+	oldBypass := ByPassedUsers
+	oldSauce := SecretSauce
+	t.Cleanup(func() {
+		ByPassedUsers = oldBypass
+		SecretSauce = oldSauce
+	})
+
+	ByPassedUsers = []string{"lauren"}
+	SecretSauce = "the-right-sauce"
+
+	rv := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UserInfo: authv1.UserInfo{
+				Username: "not-lauren",
+				Extra: map[string]authv1.ExtraValue{
+					"secret-sauce": {"the-wrong-sauce"},
+				},
+			},
+		},
+	}
+	if canPass(rv) {
+		t.Fatal("expected canPass false when neither bypass nor sauce matches")
+	}
+}
+
+// --- waitForListener unit test ---
+
+func TestWaitForListener_Ready(t *testing.T) {
+	// Save/restore shared map
+	oldProxyMap := proxyMap
+	t.Cleanup(func() { proxyMap = oldProxyMap })
+
+	// Use a fresh map for isolation
+	proxyMap = map[string]bool{}
+
+	// Mark ready before call so it should return quickly
+	id := "session-123"
+	proxyMap[id] = true
+
+	start := time.Now()
+	if err := waitForListener(id); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("waitForListener returned too slowly")
+	}
+}
+
+// --- rexecHandler early validation test ---
+
+func TestRexecHandler_MissingUserIsForbidden(t *testing.T) {
+	// No X-Remote-User header
+	req := httptest.NewRequest(http.MethodGet,
+		"/apis/audit.adyen.internal/v1beta1/namespaces/ns/pods/pod/exec", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"namespace": "ns",
+		"pod":       "pod",
+	})
+
+	rr := httptest.NewRecorder()
+
+	rexecHandler(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -31,7 +31,7 @@ func tcpForwarder(ctx context.Context) {
 	}
 	defer listener.Close()
 
-	SysLogger.Debug().Msgf("starting personal tcp forwarer at " + socketPath)
+	SysLogger.Debug().Msgf("starting personal tcp forwarer at %s", socketPath)
 
 	// in a cheap manner we signer back that it is ready
 	mapSync.Lock()
@@ -50,7 +50,7 @@ func tcpForwarder(ctx context.Context) {
 		select {
 		// once the http session is gone we stop the listener
 		case <-ctx.Done():
-			SysLogger.Debug().Msgf("stopping personal tcp forwarer at " + socketPath)
+			SysLogger.Debug().Msgf("stopping personal tcp forwarer at %s", socketPath)
 			halt = true
 		}
 		if halt {


### PR DESCRIPTION
## Summary
<!--
Describe the changes proposed in this pull request:
- Adding tests for rexec as there were no existing tests
- Fix some msg formatting issues revealed with go vet/go test
-->

## Tested scenarios
Can now run tests against rexec/server

```
go test -v ./rexec/server
=== RUN   TestExecHandlerUnsupportedContentType
--- PASS: TestExecHandlerUnsupportedContentType (0.00s)
=== RUN   TestExecHandlerBadJSON
--- PASS: TestExecHandlerBadJSON (0.00s)
=== RUN   TestExecHandlerAllowsNonExecKinds
--- PASS: TestExecHandlerAllowsNonExecKinds (0.00s)
=== RUN   TestExecHandlerBypassedUser
--- PASS: TestExecHandlerBypassedUser (0.00s)
=== RUN   TestExecHandlerSecretSauce
--- PASS: TestExecHandlerSecretSauce (0.00s)
=== RUN   TestExecHandlerExecDenied
--- PASS: TestExecHandlerExecDenied (0.00s)
=== RUN   TestCanPassBypassUser
--- PASS: TestCanPassBypassUser (0.00s)
=== RUN   TestCanPassSecretSauceMatch
--- PASS: TestCanPassSecretSauceMatch (0.00s)
=== RUN   TestCanPassNoMatch
--- PASS: TestCanPassNoMatch (0.00s)
=== RUN   TestWaitForListenerReady
--- PASS: TestWaitForListenerReady (0.00s)
=== RUN   TestRexecHandlerMissingUser
--- PASS: TestRexecHandlerMissingUser (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/rexec/server	0.437s
```

