### PR TITLE
feat: add audited copy (cp) command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+kubectl-rexec

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tests are currently implemented for the rexec/server
 
 Run the tests like:
 `go test ./rexec/server`
+`go test ./plugin`
 
 ## Documentation
 See the [Design](https://github.com/Adyen/kubectl-rexec/blob/master/DESIGN.md).

--- a/STARTED.md
+++ b/STARTED.md
@@ -18,7 +18,11 @@ Ensure that you go bin directory is in the path.
 go install github.com/adyen/kubectl-rexec@latest
 ```
 
-## Observe events 
+## Verify Installation
+```
+kubectl rexec exec --help
+kubectl rexec cp --help
+```
 
 Tail the logs of the proxy to see audit events, and ideally set up a logshipping setup that suits you to store them.
 
@@ -28,8 +32,45 @@ kubectl -n kube-system logs -l app=rexec -f
 
 ## Use the plugin
 
-The rexec plugin has the same params as the upstream exec command.
+The rexec plugin has the same params as the upstream exec and cp commands.
+
+### Execute Commands
 
 ```
-kubectl rexec exec -ti some-pod -- bash
+kubectl rexec exec -ti my-pod -- bash
+
+kubectl rexec exec my-pod -- ls -la /tmp
+
+kubectl rexec exec my-pod -c my-container -- env
+```
+
+### Copy Files (Download Only)
+
+For security reasons, only copying FROM pods is supported.
+
+Note: The `cp` command requires the `tar` binary to be installed and available in the PATH of the target container.
+
+```
+kubectl rexec cp my-pod:/var/log/app.log /tmp/app.log
+
+kubectl rexec cp my-pod:/tmp/data /tmp/data
+
+kubectl rexec cp my-pod:/var/log/app.log ./app.log -c my-container
+
+kubectl rexec cp my-namespace/my-pod:/etc/config ./config
+```
+
+## View Audit Logs
+
+Tail the logs to see all audited operations:
+
+```
+kubectl -n kube-system logs -l app=rexec -f
+```
+
+Example audit entries:
+
+```
+{"level":"info","facility":"audit","user":"alice","session":"f1e2d3c4-b5a6-7f8e-9d0c-1a2b3c4d5e6f","command":"tar cf - -C /var/log -- app.log","time":"2024-12-16T10:30:01Z"}
+{"level":"info","facility":"audit","user":"bob","session":"94f1add8-7f29-4b18-b259-99f68605149e","command":"ls -la","time":"2024-12-16T10:31:15Z"}
 ```

--- a/STARTED.md
+++ b/STARTED.md
@@ -71,6 +71,6 @@ kubectl -n kube-system logs -l app=rexec -f
 Example audit entries:
 
 ```
-{"level":"info","facility":"audit","user":"alice","session":"f1e2d3c4-b5a6-7f8e-9d0c-1a2b3c4d5e6f","command":"tar cf - -C /var/log -- app.log","time":"2024-12-16T10:30:01Z"}
-{"level":"info","facility":"audit","user":"bob","session":"94f1add8-7f29-4b18-b259-99f68605149e","command":"ls -la","time":"2024-12-16T10:31:15Z"}
+{"level":"info","facility":"audit","user":"alice","session":"oneoff","command":"tar cf - -C /var/log -- app.log","time":"2024-12-16T10:30:01Z"}
+{"level":"info","facility":"audit","user":"bob","session":"a1b2c3d4","command":"ls -la","time":"2024-12-16T10:31:15Z"}
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,16 +7,13 @@ Complete testing for `kubectl-rexec`.
 ### Running Tests
 
 ```bash
-cd plugin
-go test -v
-
-cd rexec/server
-go test -v
+go test ./rexec/server
+go test ./plugin
 
 go test -v -run TestParseFileSpec
 ```
 
-#### Plugin Tests (`plugin/`)
+## Plugin Tests (`plugin/`)
 
 | Test | Description |
 |------|-------------|
@@ -24,10 +21,16 @@ go test -v -run TestParseFileSpec
 | `TestValidateLocalDestination` | Validates local path exists |
 | `TestExtractTarSingleFile` | Extracts single file from tar |
 | `TestExtractTarDirectory` | Extracts directory from tar |
-| `TestExtractTarSymlinkSkipped` | Security: symlinks are skipped with warning |
-| `TestExtractTarValidDoubleDotFilename` | Valid filenames like `file..txt` are allowed |
+| `TestExtractTarRenameDirectory` | Extracts directory with different name |
+| `TestExtractTarLinkTypesSkipped` | Security: symlinks and hard links are skipped with warning |
+| `TestExtractTarPathTraversal` | Security: path traversal attempts are blocked |
+| `TestExtractTarValidDoubleDotFileName` | Valid filenames like `file..txt` are allowed |
+| `TestExtractTarValidDoubleDotDirectoryName` | Valid directory names with `..` are allowed |
 | `TestRunWithArgsValidation` | Rejects upload, pod-to-pod |
 | `TestValidateCopySpecs` | Validates copy specs |
+| `TestComputeSafeTarget` | Security: validates tar entry paths and targets |
+| `TestProcessTarEntry` | Tests individual tar entry processing |
+| `TestProcessTarEntryUnsupportedTypes` | Security: unsupported tar types are skipped with warning |
 
 #### Server Tests (`rexec/server/`)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,46 @@
+# Testing Guide
+
+Complete testing for `kubectl-rexec`.
+
+## Unit Tests
+
+### Running Tests
+
+```bash
+cd plugin
+go test -v
+
+cd rexec/server
+go test -v
+
+go test -v -run TestParseFileSpec
+```
+
+#### Plugin Tests (`plugin/`)
+
+| Test | Description |
+|------|-------------|
+| `TestParseFileSpec` | Parses `pod:/path` and `ns/pod:/path` |
+| `TestValidateLocalDestination` | Validates local path exists |
+| `TestExtractTarSingleFile` | Extracts single file from tar |
+| `TestExtractTarDirectory` | Extracts directory from tar |
+| `TestExtractTarSymlinkSkipped` | Security: symlinks are skipped with warning |
+| `TestExtractTarValidDoubleDotFilename` | Valid filenames like `file..txt` are allowed |
+| `TestRunWithArgsValidation` | Rejects upload, pod-to-pod |
+| `TestValidateCopySpecs` | Validates copy specs |
+
+#### Server Tests (`rexec/server/`)
+
+| Test | What It Tests |
+|------|---------------|
+| `TestExecHandlerUnsupportedContentType` | Rejects non-JSON requests |
+| `TestExecHandlerBadJSON` | Handles malformed JSON |
+| `TestExecHandlerAllowsNonExecKinds` | Allows non-PodExecOptions resources |
+| `TestExecHandlerBypassedUser` | Bypassed users can exec |
+| `TestExecHandlerSecretSauce` | Valid secret sauce allows exec |
+| `TestExecHandlerExecDenied` | Invalid requests are denied |
+| `TestCanPassBypassUser` | Bypass user logic |
+| `TestCanPassSecretSauceMatch` | Secret sauce validation |
+| `TestCanPassNoMatch` | Denial when no auth matches |
+| `TestWaitForListenerReady` | Listener readiness check |
+| `TestRexecHandlerMissingUser` | Missing user header returns 403 |

--- a/plugin/cp.go
+++ b/plugin/cp.go
@@ -326,31 +326,39 @@ func (o *CopyOptions) extractTar(reader io.Reader, destPath, srcBase string) err
 			return err
 		}
 
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(targetAbs, os.FileMode(header.Mode)); err != nil {
-				return fmt.Errorf("mkdir failed: %v", err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetAbs), 0755); err != nil {
-				return fmt.Errorf("mkdir failed: %v", err)
-			}
-			f, err := os.OpenFile(targetAbs, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
-			if err != nil {
-				return fmt.Errorf("create file failed: %v", err)
-			}
-			_, copyErr := io.Copy(f, tarReader)
-			if closeErr := f.Close(); closeErr != nil && copyErr == nil {
-				return fmt.Errorf("close file failed: %v", closeErr)
-			}
-			if copyErr != nil {
-				return fmt.Errorf("write failed: %v", copyErr)
-			}
-		case tar.TypeSymlink:
-
-		//nolint:errcheck
-			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping symlink %s -> %s (symlinks not supported for security)\n", header.Name, header.Linkname)
+		// Delegated the actual file creation to reduce cognitive complexity
+		if err := o.processTarEntry(header, tarReader, targetAbs); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+// processTarEntry handles the creation of directories, files, or skipping symlinks based on the tar header type.
+func (o *CopyOptions) processTarEntry(header *tar.Header, tarReader *tar.Reader, targetAbs string) error {
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := os.MkdirAll(targetAbs, os.FileMode(header.Mode)); err != nil {
+			return fmt.Errorf("mkdir failed: %v", err)
+		}
+	case tar.TypeReg:
+		if err := os.MkdirAll(filepath.Dir(targetAbs), 0755); err != nil {
+			return fmt.Errorf("mkdir failed: %v", err)
+		}
+		f, err := os.OpenFile(targetAbs, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+		if err != nil {
+			return fmt.Errorf("create file failed: %v", err)
+		}
+		_, copyErr := io.Copy(f, tarReader)
+		if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+			return fmt.Errorf("close file failed: %v", closeErr)
+		}
+		if copyErr != nil {
+			return fmt.Errorf("write failed: %v", copyErr)
+		}
+	case tar.TypeSymlink:
+		//nolint:errcheck
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping symlink %s -> %s (symlinks not supported for security)\n", header.Name, header.Linkname)
 	}
 	return nil
 }

--- a/plugin/cp.go
+++ b/plugin/cp.go
@@ -154,12 +154,9 @@ func validateCopySpecs(src, dest *fileSpec) error {
 func validateLocalDestination(destPath string) error {
 	destPath = filepath.Clean(destPath)
 
-	info, err := os.Stat(destPath)
+	_, err := os.Stat(destPath)
 	if err == nil {
-		if info.IsDir() {
-			return nil
-		}
-		return nil // existing file, will overwrite
+		return nil // existing file or directory
 	}
 
 	parentDir := filepath.Dir(destPath)
@@ -293,12 +290,6 @@ func (o *CopyOptions) extractTar(reader io.Reader, destPath, srcBase string) err
 	destInfo, statErr := os.Stat(destPath)
 	destIsDir := statErr == nil && destInfo.IsDir()
 
-	// Compute absolute paths for security validation
-	destPathAbs, err := filepath.Abs(destPath)
-	if err != nil {
-		return fmt.Errorf("invalid destination path: %v", err)
-	}
-
 	var baseDir string
 	if destIsDir {
 		baseDir = destPath
@@ -321,7 +312,7 @@ func (o *CopyOptions) extractTar(reader io.Reader, destPath, srcBase string) err
 		}
 
 		// Security: validate and compute safe target path
-		targetAbs, err := computeSafeTarget(header.Name, destPath, destPathAbs, baseAbs, srcBase, destIsDir)
+		targetAbs, err := computeSafeTarget(header.Name, destPath, baseAbs, srcBase, destIsDir)
 		if err != nil {
 			return err
 		}
@@ -359,13 +350,18 @@ func (o *CopyOptions) processTarEntry(header *tar.Header, tarReader *tar.Reader,
 	case tar.TypeSymlink:
 		//nolint:errcheck
 		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping symlink %s -> %s (symlinks not supported for security)\n", header.Name, header.Linkname)
+	case tar.TypeLink:
+		//nolint:errcheck
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping hard link %s -> %s (hard links not supported for security)\n", header.Name, header.Linkname)
+	default:
+		//nolint:errcheck
+		_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping unsupported tar entry %s (type %d)\n", header.Name, header.Typeflag)
 	}
 	return nil
 }
 
 // computeSafeTarget validates the tar entry name and computes a safe absolute target path.
-func computeSafeTarget(name, destPath, destPathAbs, baseAbs, srcBase string, destIsDir bool) (string, error) {
-
+func computeSafeTarget(name, destPath, baseAbs, srcBase string, destIsDir bool) (string, error) {
 	cleanName := path.Clean(name)
 
 	if cleanName == ".." || strings.HasPrefix(cleanName, "../") || path.IsAbs(cleanName) {
@@ -393,7 +389,7 @@ func computeSafeTarget(name, destPath, destPathAbs, baseAbs, srcBase string, des
 		return "", fmt.Errorf(errPathTraversal, name)
 	}
 
-	if strings.HasPrefix(rel, "..") {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf(errPathTraversal, name)
 	}
 

--- a/plugin/cp.go
+++ b/plugin/cp.go
@@ -1,0 +1,418 @@
+package plugin
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/cmd/util/podcmd"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// CopyOptions contains the options for the audited copy command.
+type CopyOptions struct {
+	Container    string
+	Namespace    string
+	ClientConfig *restclient.Config
+	Clientset    kubernetes.Interface
+	IOStreams    genericiooptions.IOStreams
+}
+
+type fileSpec struct {
+	PodName      string
+	PodNamespace string
+	File         string
+}
+
+const errPathTraversal = "illegal file path in tar: %s (path traversal attempt)"
+
+// NewCmdCp creates a new 'cp' command for the rexec plugin.
+// It supports copying files and directories from containers to the local filesystem with auditing.
+func NewCmdCp(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+	o := &CopyOptions{IOStreams: ioStreams}
+
+	cmd := &cobra.Command{
+		Use:   "cp <pod-src> <local-dest>",
+		Short: i18n.T("Copy files and directories from containers (with audit)"),
+		Long: templates.LongDesc(`
+			Copy files and directories from containers to local filesystem.
+			This command uses rexec for audited file transfers.
+
+			Note: Only copying FROM pods is supported (for security reasons).
+			Note: Requires 'tar' to be installed in the container.`),
+		Example: templates.Examples(`
+			# Copy /tmp/foo from a remote pod to /tmp/bar locally
+			kubectl rexec cp my-pod:/tmp/foo /tmp/bar
+
+			# Copy from a specific container
+			kubectl rexec cp my-pod:/tmp/foo /tmp/bar -c my-container
+
+			# Copy from a pod in a specific namespace
+			kubectl rexec cp my-namespace/my-pod:/var/log/app.log ./app.log
+
+			# Copy a directory from a remote pod
+			kubectl rexec cp my-pod:/var/log /tmp/logs`),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			if len(args) == 2 {
+				cmdutil.CheckErr(o.RunWithArgs(cmd.Context(), args[0], args[1]))
+			} else {
+				cmdutil.CheckErr(fmt.Errorf("source and destination are required"))
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.Container, "container", "c", "", "Container name. If omitted, use the first container")
+	return cmd
+}
+
+// Complete sets up the options for the copy command by initializing Kubernetes clients and configuration.
+func (o *CopyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("source and destination are required")
+	}
+
+	var err error
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.ClientConfig, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.Clientset, err = f.KubernetesClientSet()
+	return err
+}
+
+// Validate ensures that the required configuration for the copy command is present.
+func (o *CopyOptions) Validate() error {
+	if o.ClientConfig == nil {
+		return fmt.Errorf("client config is required")
+	}
+	return nil
+}
+
+// RunWithArgs parses the source and destination specifications and initiates the copy operation from the pod.
+func (o *CopyOptions) RunWithArgs(ctx context.Context, src, dest string) error {
+	srcSpec, err := parseFileSpec(src, o.Namespace)
+	if err != nil {
+		return err
+	}
+
+	destSpec, err := parseFileSpec(dest, o.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if err := validateCopySpecs(srcSpec, destSpec); err != nil {
+		return err
+	}
+
+	if err := validateLocalDestination(destSpec.File); err != nil {
+		return err
+	}
+
+	return o.copyFromPod(ctx, srcSpec, destSpec)
+}
+
+func validateCopySpecs(src, dest *fileSpec) error {
+	if src.PodName == "" && dest.PodName == "" {
+		return fmt.Errorf("source must be a pod file spec (pod:path); only pod to local copy is supported")
+	}
+	if src.PodName == "" && dest.PodName != "" {
+		return fmt.Errorf("copying to pods is not supported for security reasons; only pod to local copy is allowed")
+	}
+	if src.PodName != "" && dest.PodName != "" {
+		return fmt.Errorf("destination must be a local path, not a pod path; only pod to local copy is supported")
+	}
+	if src.PodName != "" && src.File == "" {
+		return fmt.Errorf("remote path cannot be empty")
+	}
+	return nil
+}
+
+func validateLocalDestination(destPath string) error {
+	destPath = filepath.Clean(destPath)
+
+	info, err := os.Stat(destPath)
+	if err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		return nil // existing file, will overwrite
+	}
+
+	parentDir := filepath.Dir(destPath)
+	parentInfo, err := os.Stat(parentDir)
+	if err != nil {
+		return fmt.Errorf("local directory does not exist: %s", parentDir)
+	}
+	if !parentInfo.IsDir() {
+		return fmt.Errorf("local path is not a directory: %s", parentDir)
+	}
+	return nil
+}
+
+func (o *CopyOptions) copyFromPod(ctx context.Context, src, dest *fileSpec) error {
+	pod, err := o.Clientset.CoreV1().Pods(src.PodNamespace).Get(ctx, src.PodName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("pod %s/%s not found", src.PodNamespace, src.PodName)
+	}
+
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return fmt.Errorf("pod %s/%s is not running (phase: %s)", src.PodNamespace, src.PodName, pod.Status.Phase)
+	}
+
+	containerName, err := o.resolveContainer(pod)
+	if err != nil {
+		return err
+	}
+
+	srcDir := filepath.Dir(src.File)
+	srcBase := filepath.Base(src.File)
+	command := []string{"tar", "cf", "-", "-C", srcDir, "--", srcBase}
+
+	var stdout, stderr bytes.Buffer
+	execErr := o.executeRemote(ctx, pod, containerName, command, &stdout, &stderr)
+
+	if execErr != nil {
+		return o.handleExecError(execErr, stderr.String(), src)
+	}
+
+	if stdout.Len() == 0 {
+		return fmt.Errorf("no data received from pod")
+	}
+
+	if err := o.extractTar(&stdout, dest.File, srcBase); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(o.IOStreams.Out, "Copied %s:%s to %s\n", src.PodName, src.File, dest.File); err != nil {
+		return fmt.Errorf("failed to write output: %v", err)
+	}
+	return nil
+}
+
+func (o *CopyOptions) handleExecError(execErr error, stderrStr string, src *fileSpec) error {
+	podRef := fmt.Sprintf("%s/%s", src.PodNamespace, src.PodName)
+
+	if strings.Contains(stderrStr, "tar: not found") ||
+		strings.Contains(stderrStr, "executable file not found") ||
+		strings.Contains(stderrStr, "sh: tar") {
+		return fmt.Errorf("pod %s: tar binary not found in container", podRef)
+	}
+
+	if strings.Contains(stderrStr, "No such file or directory") {
+		return fmt.Errorf("pod %s: file not found: %s", podRef, src.File)
+	}
+
+	if strings.Contains(stderrStr, "Permission denied") || strings.Contains(stderrStr, "cannot open") {
+		return fmt.Errorf("pod %s: permission denied: %s", podRef, src.File)
+	}
+
+	if stderrStr != "" {
+		return fmt.Errorf("pod %s: %s", podRef, strings.TrimSpace(stderrStr))
+	}
+
+	return fmt.Errorf("pod %s: command failed: %v", podRef, execErr)
+}
+
+func (o *CopyOptions) resolveContainer(pod *corev1.Pod) (string, error) {
+	if o.Container != "" {
+		for _, c := range pod.Spec.Containers {
+			if c.Name == o.Container {
+				return o.Container, nil
+			}
+		}
+		for _, c := range pod.Spec.InitContainers {
+			if c.Name == o.Container {
+				return o.Container, nil
+			}
+		}
+		return "", fmt.Errorf("container %q not found in pod %s/%s", o.Container, pod.Namespace, pod.Name)
+	}
+
+	container, err := podcmd.FindOrDefaultContainerByName(pod, "", false, o.IOStreams.ErrOut)
+	if err != nil {
+		return "", err
+	}
+	return container.Name, nil
+}
+
+func (o *CopyOptions) executeRemote(ctx context.Context, pod *corev1.Pod, container string, command []string, stdout, stderr *bytes.Buffer) error {
+	restClient, err := restclient.RESTClientFor(o.ClientConfig)
+	if err != nil {
+		return err
+	}
+
+	req := restClient.Post().
+		RequestURI(fmt.Sprintf("/apis/audit.adyen.internal/v1beta1/namespaces/%s/pods/%s/exec", pod.Namespace, pod.Name))
+
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(o.ClientConfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	return exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
+func (o *CopyOptions) extractTar(reader io.Reader, destPath, srcBase string) error {
+	destPath = filepath.Clean(destPath)
+	destInfo, statErr := os.Stat(destPath)
+	destIsDir := statErr == nil && destInfo.IsDir()
+
+	// Compute absolute paths for security validation
+	destPathAbs, err := filepath.Abs(destPath)
+	if err != nil {
+		return fmt.Errorf("invalid destination path: %v", err)
+	}
+
+	var baseDir string
+	if destIsDir {
+		baseDir = destPath
+	} else {
+		baseDir = filepath.Dir(destPath)
+	}
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("invalid base path: %v", err)
+	}
+
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read error: %v", err)
+		}
+
+		// Security: validate and compute safe target path
+		targetAbs, err := computeSafeTarget(header.Name, destPath, destPathAbs, baseAbs, srcBase, destIsDir)
+		if err != nil {
+			return err
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetAbs, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("mkdir failed: %v", err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(targetAbs), 0755); err != nil {
+				return fmt.Errorf("mkdir failed: %v", err)
+			}
+			f, err := os.OpenFile(targetAbs, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("create file failed: %v", err)
+			}
+			_, copyErr := io.Copy(f, tarReader)
+			if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+				return fmt.Errorf("close file failed: %v", closeErr)
+			}
+			if copyErr != nil {
+				return fmt.Errorf("write failed: %v", copyErr)
+			}
+		case tar.TypeSymlink:
+
+		//nolint:errcheck
+			_, _ = fmt.Fprintf(o.IOStreams.ErrOut, "Warning: skipping symlink %s -> %s (symlinks not supported for security)\n", header.Name, header.Linkname)
+		}
+	}
+	return nil
+}
+
+// computeSafeTarget validates the tar entry name and computes a safe absolute target path.
+func computeSafeTarget(name, destPath, destPathAbs, baseAbs, srcBase string, destIsDir bool) (string, error) {
+
+	cleanName := path.Clean(name)
+
+	if cleanName == ".." || strings.HasPrefix(cleanName, "../") || path.IsAbs(cleanName) {
+		return "", fmt.Errorf(errPathTraversal, name)
+	}
+
+	var target string
+	if destIsDir {
+		target = filepath.Join(destPath, cleanName)
+	} else {
+		rel, err := filepath.Rel(srcBase, cleanName)
+		if err != nil {
+			return "", fmt.Errorf("failed to calculate relative path: %v", err)
+		}
+		target = filepath.Join(destPath, rel)
+	}
+
+	targetAbs, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return "", fmt.Errorf("invalid target path: %v", err)
+	}
+
+	rel, err := filepath.Rel(baseAbs, targetAbs)
+	if err != nil {
+		return "", fmt.Errorf(errPathTraversal, name)
+	}
+
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf(errPathTraversal, name)
+	}
+
+	return targetAbs, nil
+}
+
+func parseFileSpec(spec, defaultNamespace string) (*fileSpec, error) {
+	if !strings.Contains(spec, ":") {
+		return &fileSpec{File: spec}, nil
+	}
+
+	parts := strings.SplitN(spec, ":", 2)
+	podSpec := parts[0]
+	filePath := parts[1]
+
+	namespace := defaultNamespace
+	podName := podSpec
+
+	if strings.Contains(podSpec, "/") {
+		nsParts := strings.SplitN(podSpec, "/", 2)
+		namespace = nsParts[0]
+		podName = nsParts[1]
+	}
+
+	return &fileSpec{
+		PodName:      podName,
+		PodNamespace: namespace,
+		File:         filePath,
+	}, nil
+}

--- a/plugin/cp_test.go
+++ b/plugin/cp_test.go
@@ -24,7 +24,65 @@ const (
 	contentStr      = "content\n"
 	localPath       = "/local"
 	fileDotTxt      = "file..txt"
+	testDirName     = "testdir"
+	maliciousPath1  = "../etc/passwd"
+	maliciousPath2  = "/etc/passwd"
+	maliciousPath3  = ".."
+	traversalErrorMsg = "illegal file path"
+	errWriteTarHeaderFmt     = "failed to write tar header: %v"
+	errWriteTarContentFmt    = "failed to write tar content: %v"
+	errCloseTarWriterFmt     = "failed to close tar writer: %v"
+	errWriteTarHeaderForFmt  = "failed to write tar header for %q: %v"
+	errWriteTarContentForFmt = "failed to write tar content for %q: %v"
 )
+
+type computeSafeTargetCase struct {
+	name        string
+	nameInTar   string
+	destPath    string
+	srcBase     string
+	destIsDir   bool
+	wantErr     bool
+	errContains string
+}
+
+type linkTestCase struct {
+	name       string
+	linkName   string
+	typeflag   byte
+	warnSubstr string
+}
+
+func mustTempDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	return tmpDir
+}
+
+func newCopyOptions(errOut io.Writer) *CopyOptions {
+	return &CopyOptions{
+		IOStreams: genericiooptions.IOStreams{
+			Out:    io.Discard,
+			ErrOut: errOut,
+		},
+	}
+}
+
+func newDefaultCopyOptions() *CopyOptions {
+	return newCopyOptions(io.Discard)
+}
+
+func newRunOptions() *CopyOptions {
+	return &CopyOptions{
+		IOStreams: genericiooptions.IOStreams{Out: io.Discard, ErrOut: io.Discard},
+		Namespace: "default",
+	}
+}
 
 func TestParseFileSpec(t *testing.T) {
 	tests := []struct {
@@ -53,11 +111,7 @@ func TestParseFileSpec(t *testing.T) {
 }
 
 func TestValidateLocalDestination(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := mustTempDir(t)
 
 	testFile := filepath.Join(tmpDir, "file.txt")
 	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
@@ -72,7 +126,7 @@ func TestValidateLocalDestination(t *testing.T) {
 		{"existing dir", tmpDir, false},
 		{"existing file", testFile, false},
 		{"new file in dir", filepath.Join(tmpDir, "new.txt"), false},
-		{"parent missing", "/nonexistent/file.txt", true},
+		{"parent missing", filepath.Join(tmpDir, "missing-parent", "file.txt"), true},
 	}
 
 	for _, tt := range tests {
@@ -85,95 +139,172 @@ func TestValidateLocalDestination(t *testing.T) {
 	}
 }
 
-func TestExtractTarSingleFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
+type extractTarScenario struct {
+	name       string
+	files      map[string]string
+	srcBase    string
+	renameDest string
+	assertions func(t *testing.T, tmpDir string, destPath string)
+}
+
+func runExtractTarScenarioCase(t *testing.T, tt extractTarScenario) {
+	t.Helper()
+
+	tmpDir := mustTempDir(t)
+	opts := newDefaultCopyOptions()
+	tarBuf := createTestTar(t, tt.files)
+
+	destPath := tmpDir
+	if tt.renameDest != "" {
+		destPath = filepath.Join(tmpDir, tt.renameDest)
 	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
-	tarBuf := createTestTar(t, map[string]string{myFileTxt: contentStr})
-
-	if err := opts.extractTar(tarBuf, tmpDir, myFileTxt); err != nil {
+	if err := opts.extractTar(tarBuf, destPath, tt.srcBase); err != nil {
 		t.Fatalf(errExtractTar, err)
 	}
 
-	content, _ := os.ReadFile(filepath.Join(tmpDir, myFileTxt))
-	if string(content) != contentStr {
-		t.Errorf("content = %q, want %q", content, contentStr)
-	}
+	tt.assertions(t, tmpDir, destPath)
+}
+
+func TestExtractTarSingleFile(t *testing.T) {
+	runExtractTarScenarioCase(t, extractTarScenario{
+		name:    "single file",
+		files:   map[string]string{myFileTxt: contentStr},
+		srcBase: myFileTxt,
+		assertions: func(t *testing.T, tmpDir string, destPath string) {
+			content, err := os.ReadFile(filepath.Join(destPath, myFileTxt))
+			if err != nil {
+				t.Fatalf("failed to read extracted file: %v", err)
+			}
+			if string(content) != contentStr {
+				t.Errorf("content = %q, want %q", content, contentStr)
+			}
+		},
+	})
 }
 
 func TestExtractTarDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
-	tarBuf := createTestTar(t, map[string]string{
-		"mydir/file1.txt":        content1Str,
-		"mydir/subdir/file2.txt": content2Str,
+	runExtractTarScenarioCase(t, extractTarScenario{
+		name:    "directory",
+		files:   map[string]string{"mydir/file1.txt": content1Str, "mydir/subdir/file2.txt": content2Str},
+		srcBase: "mydir",
+		assertions: func(t *testing.T, tmpDir string, destPath string) {
+			content1, err := os.ReadFile(filepath.Join(destPath, "mydir/file1.txt"))
+			if err != nil {
+				t.Fatalf("failed to read extracted file1: %v", err)
+			}
+			content2, err := os.ReadFile(filepath.Join(destPath, "mydir/subdir/file2.txt"))
+			if err != nil {
+				t.Fatalf("failed to read extracted file2: %v", err)
+			}
+			if string(content1) != content1Str || string(content2) != content2Str {
+				t.Errorf("unexpected content")
+			}
+		},
 	})
-
-	if err := opts.extractTar(tarBuf, tmpDir, "mydir"); err != nil {
-		t.Fatalf(errExtractTar, err)
-	}
-
-	content1, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/file1.txt"))
-	content2, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/subdir/file2.txt"))
-	if string(content1) != content1Str || string(content2) != content2Str {
-		t.Errorf("unexpected content")
-	}
 }
 
-func TestExtractTarSymlinkSkipped(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+func TestExtractTarRenameDirectory(t *testing.T) {
+	runExtractTarScenarioCase(t, extractTarScenario{
+		name:       "rename directory",
+		files:      map[string]string{"testdir/file1.txt": content1Str},
+		srcBase:    "testdir",
+		renameDest: "downloaded",
+		assertions: func(t *testing.T, tmpDir string, destPath string) {
+			content, err := os.ReadFile(filepath.Join(destPath, "file1.txt"))
+			if err != nil {
+				t.Fatalf("failed to read extracted file: %v", err)
+			}
+			if string(content) != content1Str {
+				t.Errorf("unexpected content")
+			}
+		},
+	})
+}
 
-	var stderr bytes.Buffer
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: &stderr}}
+func createLinkTar(t *testing.T, linkName string, typeflag byte, target string) *bytes.Buffer {
+	t.Helper()
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	_ = tw.WriteHeader(&tar.Header{Name: targetTxtFile, Mode: 0644, Size: 7})
-	_, _ = tw.Write([]byte("content"))
-	_ = tw.WriteHeader(&tar.Header{Name: "link.txt", Typeflag: tar.TypeSymlink, Linkname: targetTxtFile})
-	_ = tw.Close()
 
-	if err := opts.extractTar(&buf, tmpDir, targetTxtFile); err != nil {
+	if err := tw.WriteHeader(&tar.Header{Name: targetTxtFile, Mode: 0644, Size: 7}); err != nil {
+		t.Fatalf(errWriteTarHeaderFmt, err)
+	}
+	if _, err := tw.Write([]byte("content")); err != nil {
+		t.Fatalf(errWriteTarContentFmt, err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     linkName,
+		Typeflag: typeflag,
+		Linkname: target,
+	}); err != nil {
+		t.Fatalf("failed to write link header: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf(errCloseTarWriterFmt, err)
+	}
+
+	return &buf
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("%s should exist", path)
+	}
+}
+
+func assertFileDoesNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err == nil {
+		t.Errorf("%s should NOT exist", path)
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("expected warning containing %q, got: %s", want, got)
+	}
+}
+
+func runExtractTarLinkTypesSkippedCase(t *testing.T, tt linkTestCase) {
+	t.Helper()
+
+	tmpDir := mustTempDir(t)
+	var stderr bytes.Buffer
+	opts := newCopyOptions(&stderr)
+	tarBuf := createLinkTar(t, tt.linkName, tt.typeflag, targetTxtFile)
+
+	if err := opts.extractTar(tarBuf, tmpDir, targetTxtFile); err != nil {
 		t.Fatalf(errExtractTar, err)
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpDir, targetTxtFile)); err != nil {
-		t.Error("target.txt should exist")
+	assertFileExists(t, filepath.Join(tmpDir, targetTxtFile))
+	assertFileDoesNotExist(t, filepath.Join(tmpDir, tt.linkName))
+	assertContains(t, stderr.String(), tt.warnSubstr)
+}
+
+func TestExtractTarLinkTypesSkipped(t *testing.T) {
+	tests := []linkTestCase{
+		{"symlink", "link.txt", tar.TypeSymlink, "skipping symlink"},
+		{"hardlink", "hardlink.txt", tar.TypeLink, "skipping hard link"},
 	}
 
-	if _, err := os.Lstat(filepath.Join(tmpDir, "link.txt")); err == nil {
-		t.Error("link.txt should NOT exist (symlinks should be skipped for security)")
-	}
-
-	if !strings.Contains(stderr.String(), "skipping symlink") {
-		t.Errorf("expected warning about skipping symlink, got: %s", stderr.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runExtractTarLinkTypesSkippedCase(t, tt)
+		})
 	}
 }
 
 func TestExtractTarPathTraversal(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+	tmpDir := mustTempDir(t)
+	opts := newDefaultCopyOptions()
 	tarBuf := createTestTar(t, map[string]string{"../../../etc/malicious.txt": "bad\n"})
 
-	err = opts.extractTar(tarBuf, tmpDir, "malicious.txt")
+	err := opts.extractTar(tarBuf, tmpDir, "malicious.txt")
 	if err == nil {
 		t.Fatal("extractTar() should have failed with path traversal attempt")
 	}
@@ -181,61 +312,42 @@ func TestExtractTarPathTraversal(t *testing.T) {
 		t.Errorf("error = %v, want containing 'illegal file path'", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpDir, "../../../etc/malicious.txt")); err == nil {
-		t.Error("malicious file should NOT have been created")
+	files, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read destination dir: %v", err)
+	}
+	if len(files) > 0 {
+		t.Errorf("Expected no files in destination, got: %v", files)
 	}
 }
 
-func TestExtractTarValidDoubleDotFilename(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+func TestExtractTarValidDoubleDotFileName(t *testing.T) {
+	tmpDir := mustTempDir(t)
+	opts := newDefaultCopyOptions()
 
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
 	tarBuf := createTestTar(t, map[string]string{
-		fileDotTxt:        content1Str,
-		"dir/..hidden/file": content2Str,
+		fileDotTxt: content1Str,
 	})
-
 	if err := opts.extractTar(tarBuf, tmpDir, fileDotTxt); err != nil {
 		t.Fatalf("extractTar() should allow valid filenames with '..': %v", err)
 	}
-
 	if _, err := os.Stat(filepath.Join(tmpDir, fileDotTxt)); err != nil {
 		t.Error("file..txt should exist (valid filename with double dots)")
 	}
-	if _, err := os.Stat(filepath.Join(tmpDir, "dir/..hidden/file")); err != nil {
-		t.Error("dir/..hidden/file should exist (valid directory with double dots)")
-	}
 }
 
-func TestExtractTarRenameDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", testTempPattern)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+func TestExtractTarValidDoubleDotDirectoryName(t *testing.T) {
+	tmpDir := mustTempDir(t)
+	opts := newDefaultCopyOptions()
 
 	tarBuf := createTestTar(t, map[string]string{
-		"testdir/file1.txt": content1Str,
+		"dir/..hidden/file": content2Str,
 	})
-
-	newDestPath := filepath.Join(tmpDir, "downloaded")
-
-	if err := opts.extractTar(tarBuf, newDestPath, "testdir"); err != nil {
-		t.Fatalf(errExtractTar, err)
+	if err := opts.extractTar(tarBuf, tmpDir, ""); err != nil {
+		t.Fatalf("extractTar() should allow valid directory names with '..': %v", err)
 	}
-
-	content, err := os.ReadFile(filepath.Join(newDestPath, "file1.txt"))
-	if err != nil {
-		t.Fatalf("Failed to read extracted file, it was put in the wrong place: %v", err)
-	}
-	if string(content) != content1Str {
-		t.Errorf("unexpected content")
+	if _, err := os.Stat(filepath.Join(tmpDir, "dir/..hidden/file")); err != nil {
+		t.Error("dir/..hidden/file should exist (valid directory with double dots)")
 	}
 }
 
@@ -251,10 +363,7 @@ func TestRunWithArgsValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := &CopyOptions{
-				IOStreams: genericiooptions.IOStreams{Out: io.Discard, ErrOut: io.Discard},
-				Namespace: "default",
-			}
+			o := newRunOptions()
 			err := o.RunWithArgs(context.Background(), tt.src, tt.dest)
 			if err == nil || !strings.Contains(err.Error(), tt.errContains) {
 				t.Errorf("err = %v, want containing %q", err, tt.errContains)
@@ -289,12 +398,175 @@ func TestValidateCopySpecs(t *testing.T) {
 // createTestTar creates a tar archive for testing
 func createTestTar(t *testing.T, files map[string]string) *bytes.Buffer {
 	t.Helper()
+
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 	for name, content := range files {
-		_ = tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))})
-		_, _ = tw.Write([]byte(content))
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}); err != nil {
+			t.Fatalf(errWriteTarHeaderForFmt, name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf(errWriteTarContentForFmt, name, err)
+		}
 	}
-	_ = tw.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatalf(errCloseTarWriterFmt, err)
+	}
 	return &buf
+}
+
+func TestComputeSafeTarget(t *testing.T) {
+	tmpDir := mustTempDir(t)
+
+	tests := []computeSafeTargetCase{
+		{"normal file", myFileTxt, tmpDir, "", true, false, ""},
+		{"bad path", maliciousPath1, tmpDir, "", true, true, traversalErrorMsg},
+		{"absolute path", maliciousPath2, tmpDir, "", true, true, traversalErrorMsg},
+		{"double dot", maliciousPath3, tmpDir, "", true, true, traversalErrorMsg},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testComputeSafeTargetCase(t, tt)
+		})
+	}
+}
+
+func testComputeSafeTargetCase(t *testing.T, tt computeSafeTargetCase) {
+	t.Helper()
+	baseAbs, err := filepath.Abs(tt.destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := computeSafeTarget(tt.nameInTar, tt.destPath, baseAbs, tt.srcBase, tt.destIsDir)
+
+	if (err != nil) != tt.wantErr {
+		t.Errorf("computeSafeTarget() error = %v, wantErr %v", err, tt.wantErr)
+	}
+
+	if err != nil && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+		t.Errorf("error = %v, want containing %q", err, tt.errContains)
+	}
+
+	if err == nil && result == "" {
+		t.Error("expected non-empty result on success")
+	}
+}
+
+func TestProcessTarEntry(t *testing.T) {
+	tmpDir := mustTempDir(t)
+
+	tests := []struct {
+		name    string
+		header  *tar.Header
+		content []byte
+		wantErr bool
+	}{
+		{"regular file", &tar.Header{Name: myFileTxt, Typeflag: tar.TypeReg, Mode: 0644, Size: 5}, []byte("hello"), false},
+		{"directory", &tar.Header{Name: testDirName, Typeflag: tar.TypeDir, Mode: 0755}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tarReader := createTarReader(t, tt.header, tt.content)
+			o := newDefaultCopyOptions()
+			targetPath := filepath.Join(tmpDir, tt.header.Name)
+			testProcessTarEntryScenario(t, o, tt.header, tarReader, targetPath, tt.content, tt.wantErr)
+		})
+	}
+}
+
+func testProcessTarEntryScenario(t *testing.T, o *CopyOptions, header *tar.Header, tarReader *tar.Reader, targetPath string, content []byte, wantErr bool) {
+	t.Helper()
+	err := o.processTarEntry(header, tarReader, targetPath)
+	if (err != nil) != wantErr {
+		t.Errorf("processTarEntry() error = %v, wantErr %v", err, wantErr)
+	}
+
+	if err == nil {
+		validateTarResult(t, header, targetPath, string(content))
+	}
+}
+
+func createTarReader(t *testing.T, header *tar.Header, content []byte) *tar.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf(errWriteTarHeaderFmt, err)
+	}
+	if content != nil {
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf(errWriteTarContentFmt, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf(errCloseTarWriterFmt, err)
+	}
+
+	tarReader := tar.NewReader(&buf)
+	if _, err := tarReader.Next(); err != nil {
+		t.Fatalf("failed to advance tar reader: %v", err)
+	}
+	return tarReader
+}
+
+func TestProcessTarEntryUnsupportedTypes(t *testing.T) {
+	tmpDir := mustTempDir(t)
+
+	tests := []struct {
+		name   string
+		header *tar.Header
+	}{
+		{"block device", &tar.Header{Name: "device", Typeflag: tar.TypeBlock, Mode: 0644}},
+		{"char device", &tar.Header{Name: "chardev", Typeflag: tar.TypeChar, Mode: 0644}},
+		{"fifo", &tar.Header{Name: "fifo", Typeflag: tar.TypeFifo, Mode: 0644}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			o := newCopyOptions(&stderr)
+
+			tarReader := createTarReader(t, tt.header, nil)
+			targetPath := filepath.Join(tmpDir, tt.header.Name)
+
+			err := o.processTarEntry(tt.header, tarReader, targetPath)
+			if err != nil {
+				t.Errorf("processTarEntry() should not error for unsupported type, got: %v", err)
+			}
+
+			if !strings.Contains(stderr.String(), "skipping unsupported tar entry") {
+				t.Errorf("Expected warning for unsupported tar entry, got: %s", stderr.String())
+			}
+
+			if _, err := os.Stat(targetPath); err == nil {
+				t.Errorf("Unsupported tar entry should not create file: %s", tt.header.Name)
+			}
+		})
+	}
+}
+
+func validateTarResult(t *testing.T, header *tar.Header, targetPath string, wantContent string) {
+	t.Helper()
+	if header.Typeflag == tar.TypeReg {
+		content, err := os.ReadFile(targetPath)
+		if err != nil {
+			t.Errorf("file should exist, got error: %v", err)
+		}
+		if string(content) != wantContent {
+			t.Errorf("wrong content, expected '%s', got: %s", wantContent, string(content))
+		}
+	}
+
+	if header.Typeflag == tar.TypeDir {
+		info, err := os.Stat(targetPath)
+		if err != nil {
+			t.Errorf("directory should exist, got error: %v", err)
+		}
+		if !info.IsDir() {
+			t.Error("target should be a directory")
+		}
+	}
 }

--- a/plugin/cp_test.go
+++ b/plugin/cp_test.go
@@ -1,0 +1,287 @@
+package plugin
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+func TestParseFileSpec(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      string
+		namespace string
+		want      *fileSpec
+	}{
+		{"local file", "/tmp/foo", "default", &fileSpec{File: "/tmp/foo"}},
+		{"pod file", "my-pod:/tmp/foo", "default", &fileSpec{PodName: "my-pod", PodNamespace: "default", File: "/tmp/foo"}},
+		{"pod with namespace", "kube-system/my-pod:/tmp/foo", "default", &fileSpec{PodName: "my-pod", PodNamespace: "kube-system", File: "/tmp/foo"}},
+		{"path with colon", "pod:path:extra", "default", &fileSpec{PodName: "pod", PodNamespace: "default", File: "path:extra"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFileSpec(tt.spec, tt.namespace)
+			if err != nil {
+				t.Fatalf("parseFileSpec() error = %v", err)
+			}
+			if got.File != tt.want.File || got.PodName != tt.want.PodName || got.PodNamespace != tt.want.PodNamespace {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateLocalDestination(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	testFile := filepath.Join(tmpDir, "file.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		dest    string
+		wantErr bool
+	}{
+		{"existing dir", tmpDir, false},
+		{"existing file", testFile, false},
+		{"new file in dir", filepath.Join(tmpDir, "new.txt"), false},
+		{"parent missing", "/nonexistent/file.txt", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLocalDestination(tt.dest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractTarSingleFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+	tarBuf := createTestTar(t, map[string]string{"myfile.txt": "content\n"})
+
+	if err := opts.extractTar(tarBuf, tmpDir, "myfile.txt"); err != nil {
+		t.Fatalf("extractTar error: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(tmpDir, "myfile.txt"))
+	if string(content) != "content\n" {
+		t.Errorf("content = %q, want %q", content, "content\n")
+	}
+}
+
+func TestExtractTarDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+	tarBuf := createTestTar(t, map[string]string{
+		"mydir/file1.txt":        "content1\n",
+		"mydir/subdir/file2.txt": "content2\n",
+	})
+
+	if err := opts.extractTar(tarBuf, tmpDir, "mydir"); err != nil {
+		t.Fatalf("extractTar error: %v", err)
+	}
+
+	content1, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/file1.txt"))
+	content2, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/subdir/file2.txt"))
+	if string(content1) != "content1\n" || string(content2) != "content2\n" {
+		t.Errorf("unexpected content")
+	}
+}
+
+func TestExtractTarSymlinkSkipped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	var stderr bytes.Buffer
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: &stderr}}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "target.txt", Mode: 0644, Size: 7})
+	_, _ = tw.Write([]byte("content"))
+	_ = tw.WriteHeader(&tar.Header{Name: "link.txt", Typeflag: tar.TypeSymlink, Linkname: "target.txt"})
+	_ = tw.Close()
+
+	if err := opts.extractTar(&buf, tmpDir, "target.txt"); err != nil {
+		t.Fatalf("extractTar error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "target.txt")); err != nil {
+		t.Error("target.txt should exist")
+	}
+
+	if _, err := os.Lstat(filepath.Join(tmpDir, "link.txt")); err == nil {
+		t.Error("link.txt should NOT exist (symlinks should be skipped for security)")
+	}
+
+	if !strings.Contains(stderr.String(), "skipping symlink") {
+		t.Errorf("expected warning about skipping symlink, got: %s", stderr.String())
+	}
+}
+
+func TestExtractTarPathTraversal(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+	tarBuf := createTestTar(t, map[string]string{"../../../etc/malicious.txt": "bad\n"})
+
+	err = opts.extractTar(tarBuf, tmpDir, "malicious.txt")
+	if err == nil {
+		t.Fatal("extractTar() should have failed with path traversal attempt")
+	}
+	if !strings.Contains(err.Error(), "illegal file path") {
+		t.Errorf("error = %v, want containing 'illegal file path'", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "../../../etc/malicious.txt")); err == nil {
+		t.Error("malicious file should NOT have been created")
+	}
+}
+
+func TestExtractTarValidDoubleDotFilename(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+	tarBuf := createTestTar(t, map[string]string{
+		"file..txt":        "content1\n",
+		"dir/..hidden/file": "content2\n",
+	})
+
+	if err := opts.extractTar(tarBuf, tmpDir, "file..txt"); err != nil {
+		t.Fatalf("extractTar() should allow valid filenames with '..': %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "file..txt")); err != nil {
+		t.Error("file..txt should exist (valid filename with double dots)")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "dir/..hidden/file")); err != nil {
+		t.Error("dir/..hidden/file should exist (valid directory with double dots)")
+	}
+}
+
+func TestExtractTarRenameDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
+
+	tarBuf := createTestTar(t, map[string]string{
+		"testdir/file1.txt": "content1\n",
+	})
+
+	newDestPath := filepath.Join(tmpDir, "downloaded")
+
+	if err := opts.extractTar(tarBuf, newDestPath, "testdir"); err != nil {
+		t.Fatalf("extractTar error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(newDestPath, "file1.txt"))
+	if err != nil {
+		t.Fatalf("Failed to read extracted file, it was put in the wrong place: %v", err)
+	}
+	if string(content) != "content1\n" {
+		t.Errorf("unexpected content")
+	}
+}
+
+func TestRunWithArgsValidation(t *testing.T) {
+	tests := []struct {
+		name, src, dest, errContains string
+	}{
+		{"upload blocked", "/tmp/file", "pod:/tmp/file", "copying to pods is not supported"},
+		{"pod to pod blocked", "pod1:/tmp/file", "pod2:/tmp/file", "destination must be a local path"},
+		{"local to local", "/tmp/src", "/tmp/dest", "source must be a pod file spec"},
+		{"empty path", "pod:", "/tmp/dest", "remote path cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &CopyOptions{
+				IOStreams: genericiooptions.IOStreams{Out: io.Discard, ErrOut: io.Discard},
+				Namespace: "default",
+			}
+			err := o.RunWithArgs(context.Background(), tt.src, tt.dest)
+			if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("err = %v, want containing %q", err, tt.errContains)
+			}
+		})
+	}
+}
+
+func TestValidateCopySpecs(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     *fileSpec
+		dest    *fileSpec
+		wantErr bool
+	}{
+		{"valid", &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, &fileSpec{File: "/local"}, false},
+		{"upload", &fileSpec{File: "/local"}, &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, true},
+		{"pod to pod", &fileSpec{PodName: "p1", PodNamespace: "ns", File: "/f"}, &fileSpec{PodName: "p2", PodNamespace: "ns", File: "/f"}, true},
+		{"empty path", &fileSpec{PodName: "pod", PodNamespace: "ns", File: ""}, &fileSpec{File: "/local"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCopySpecs(tt.src, tt.dest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// createTestTar creates a tar archive for testing
+func createTestTar(t *testing.T, files map[string]string) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, content := range files {
+		_ = tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))})
+		_, _ = tw.Write([]byte(content))
+	}
+	_ = tw.Close()
+	return &buf
+}

--- a/plugin/cp_test.go
+++ b/plugin/cp_test.go
@@ -13,6 +13,19 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
+const (
+	testTempPattern = "test-*"
+	targetTxtFile   = "target.txt"
+	tmpFooPath      = "/tmp/foo"
+	errExtractTar   = "extractTar error: %v"
+	myFileTxt       = "myfile.txt"
+	content1Str     = "content1\n"
+	content2Str     = "content2\n"
+	contentStr      = "content\n"
+	localPath       = "/local"
+	fileDotTxt      = "file..txt"
+)
+
 func TestParseFileSpec(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -20,9 +33,9 @@ func TestParseFileSpec(t *testing.T) {
 		namespace string
 		want      *fileSpec
 	}{
-		{"local file", "/tmp/foo", "default", &fileSpec{File: "/tmp/foo"}},
-		{"pod file", "my-pod:/tmp/foo", "default", &fileSpec{PodName: "my-pod", PodNamespace: "default", File: "/tmp/foo"}},
-		{"pod with namespace", "kube-system/my-pod:/tmp/foo", "default", &fileSpec{PodName: "my-pod", PodNamespace: "kube-system", File: "/tmp/foo"}},
+		{"local file", tmpFooPath, "default", &fileSpec{File: tmpFooPath}},
+		{"pod file", "my-pod:" + tmpFooPath, "default", &fileSpec{PodName: "my-pod", PodNamespace: "default", File: tmpFooPath}},
+		{"pod with namespace", "kube-system/my-pod:" + tmpFooPath, "default", &fileSpec{PodName: "my-pod", PodNamespace: "kube-system", File: tmpFooPath}},
 		{"path with colon", "pod:path:extra", "default", &fileSpec{PodName: "pod", PodNamespace: "default", File: "path:extra"}},
 	}
 
@@ -40,7 +53,7 @@ func TestParseFileSpec(t *testing.T) {
 }
 
 func TestValidateLocalDestination(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,27 +86,27 @@ func TestValidateLocalDestination(t *testing.T) {
 }
 
 func TestExtractTarSingleFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
-	tarBuf := createTestTar(t, map[string]string{"myfile.txt": "content\n"})
+	tarBuf := createTestTar(t, map[string]string{myFileTxt: contentStr})
 
-	if err := opts.extractTar(tarBuf, tmpDir, "myfile.txt"); err != nil {
-		t.Fatalf("extractTar error: %v", err)
+	if err := opts.extractTar(tarBuf, tmpDir, myFileTxt); err != nil {
+		t.Fatalf(errExtractTar, err)
 	}
 
-	content, _ := os.ReadFile(filepath.Join(tmpDir, "myfile.txt"))
-	if string(content) != "content\n" {
-		t.Errorf("content = %q, want %q", content, "content\n")
+	content, _ := os.ReadFile(filepath.Join(tmpDir, myFileTxt))
+	if string(content) != contentStr {
+		t.Errorf("content = %q, want %q", content, contentStr)
 	}
 }
 
 func TestExtractTarDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,23 +114,23 @@ func TestExtractTarDirectory(t *testing.T) {
 
 	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
 	tarBuf := createTestTar(t, map[string]string{
-		"mydir/file1.txt":        "content1\n",
-		"mydir/subdir/file2.txt": "content2\n",
+		"mydir/file1.txt":        content1Str,
+		"mydir/subdir/file2.txt": content2Str,
 	})
 
 	if err := opts.extractTar(tarBuf, tmpDir, "mydir"); err != nil {
-		t.Fatalf("extractTar error: %v", err)
+		t.Fatalf(errExtractTar, err)
 	}
 
 	content1, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/file1.txt"))
 	content2, _ := os.ReadFile(filepath.Join(tmpDir, "mydir/subdir/file2.txt"))
-	if string(content1) != "content1\n" || string(content2) != "content2\n" {
+	if string(content1) != content1Str || string(content2) != content2Str {
 		t.Errorf("unexpected content")
 	}
 }
 
 func TestExtractTarSymlinkSkipped(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,16 +141,16 @@ func TestExtractTarSymlinkSkipped(t *testing.T) {
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	_ = tw.WriteHeader(&tar.Header{Name: "target.txt", Mode: 0644, Size: 7})
+	_ = tw.WriteHeader(&tar.Header{Name: targetTxtFile, Mode: 0644, Size: 7})
 	_, _ = tw.Write([]byte("content"))
-	_ = tw.WriteHeader(&tar.Header{Name: "link.txt", Typeflag: tar.TypeSymlink, Linkname: "target.txt"})
+	_ = tw.WriteHeader(&tar.Header{Name: "link.txt", Typeflag: tar.TypeSymlink, Linkname: targetTxtFile})
 	_ = tw.Close()
 
-	if err := opts.extractTar(&buf, tmpDir, "target.txt"); err != nil {
-		t.Fatalf("extractTar error: %v", err)
+	if err := opts.extractTar(&buf, tmpDir, targetTxtFile); err != nil {
+		t.Fatalf(errExtractTar, err)
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpDir, "target.txt")); err != nil {
+	if _, err := os.Stat(filepath.Join(tmpDir, targetTxtFile)); err != nil {
 		t.Error("target.txt should exist")
 	}
 
@@ -151,7 +164,7 @@ func TestExtractTarSymlinkSkipped(t *testing.T) {
 }
 
 func TestExtractTarPathTraversal(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +187,7 @@ func TestExtractTarPathTraversal(t *testing.T) {
 }
 
 func TestExtractTarValidDoubleDotFilename(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,15 +195,15 @@ func TestExtractTarValidDoubleDotFilename(t *testing.T) {
 
 	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
 	tarBuf := createTestTar(t, map[string]string{
-		"file..txt":        "content1\n",
-		"dir/..hidden/file": "content2\n",
+		fileDotTxt:        content1Str,
+		"dir/..hidden/file": content2Str,
 	})
 
-	if err := opts.extractTar(tarBuf, tmpDir, "file..txt"); err != nil {
+	if err := opts.extractTar(tarBuf, tmpDir, fileDotTxt); err != nil {
 		t.Fatalf("extractTar() should allow valid filenames with '..': %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpDir, "file..txt")); err != nil {
+	if _, err := os.Stat(filepath.Join(tmpDir, fileDotTxt)); err != nil {
 		t.Error("file..txt should exist (valid filename with double dots)")
 	}
 	if _, err := os.Stat(filepath.Join(tmpDir, "dir/..hidden/file")); err != nil {
@@ -199,7 +212,7 @@ func TestExtractTarValidDoubleDotFilename(t *testing.T) {
 }
 
 func TestExtractTarRenameDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "test-*")
+	tmpDir, err := os.MkdirTemp("", testTempPattern)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,20 +221,20 @@ func TestExtractTarRenameDirectory(t *testing.T) {
 	opts := &CopyOptions{IOStreams: genericiooptions.IOStreams{ErrOut: io.Discard}}
 
 	tarBuf := createTestTar(t, map[string]string{
-		"testdir/file1.txt": "content1\n",
+		"testdir/file1.txt": content1Str,
 	})
 
 	newDestPath := filepath.Join(tmpDir, "downloaded")
 
 	if err := opts.extractTar(tarBuf, newDestPath, "testdir"); err != nil {
-		t.Fatalf("extractTar error: %v", err)
+		t.Fatalf(errExtractTar, err)
 	}
 
 	content, err := os.ReadFile(filepath.Join(newDestPath, "file1.txt"))
 	if err != nil {
 		t.Fatalf("Failed to read extracted file, it was put in the wrong place: %v", err)
 	}
-	if string(content) != "content1\n" {
+	if string(content) != content1Str {
 		t.Errorf("unexpected content")
 	}
 }
@@ -257,10 +270,10 @@ func TestValidateCopySpecs(t *testing.T) {
 		dest    *fileSpec
 		wantErr bool
 	}{
-		{"valid", &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, &fileSpec{File: "/local"}, false},
-		{"upload", &fileSpec{File: "/local"}, &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, true},
+		{"valid", &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, &fileSpec{File: localPath}, false},
+		{"upload", &fileSpec{File: localPath}, &fileSpec{PodName: "pod", PodNamespace: "ns", File: "/tmp/f"}, true},
 		{"pod to pod", &fileSpec{PodName: "p1", PodNamespace: "ns", File: "/f"}, &fileSpec{PodName: "p2", PodNamespace: "ns", File: "/f"}, true},
-		{"empty path", &fileSpec{PodName: "pod", PodNamespace: "ns", File: ""}, &fileSpec{File: "/local"}, true},
+		{"empty path", &fileSpec{PodName: "pod", PodNamespace: "ns", File: ""}, &fileSpec{File: localPath}, true},
 	}
 
 	for _, tt := range tests {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -53,7 +53,7 @@ func Rexec() {
 		Use:   "rexec",
 		Short: i18n.T("rexec plugin for kubectl exec"),
 		Long: templates.LongDesc(`
-      provides audited way to perform kubectl exec.`),
+      provides audited way to perform kubectl exec and cp.`),
 	}
 
 	cmds.SetGlobalNormalizationFunc(cliflag.WarnWordSepNormalizeFunc)
@@ -69,6 +69,7 @@ func Rexec() {
 
 	f := cmdutil.NewFactory(MatchVersionKubeConfigFlags)
 
+	// Create exec command
 	originalExec := cmdexec.NewCmdExec(f, kubectlOptions.IOStreams)
 
 	options := &cmdexec.ExecOptions{
@@ -108,7 +109,9 @@ func Rexec() {
 	newExec.Flags().BoolVarP(&roptions.ExecOptions.TTY, "tty", "t", roptions.ExecOptions.TTY, "Stdin is a TTY")
 	newExec.Flags().BoolVarP(&roptions.ExecOptions.Quiet, "quiet", "q", roptions.ExecOptions.Quiet, "Only print output from the remote session")
 
+	// Add both commands
 	cmds.AddCommand(newExec)
+	cmds.AddCommand(NewCmdCp(f, kubectlOptions.IOStreams))
 
 	cmds.Execute()
 }


### PR DESCRIPTION
## Summary

We are using rexec for recorded access for containers inside k8s clusters. For webapps and jobs we also need copy functionality. Since kubectl cp depends on exec, we implemented our own copy using rexec.

**Security Reasons:** Only copying FROM pods is supported (download only). Copying TO pods is intentionally disabled for security reasons.

### Changes in this PR

- Implement `kubectl rexec cp` for audited file transfers (download only)
- Add comprehensive tests for cp functionality
- Update documentation with cp command examples

## Unit Testing
```bash
❯ cd plugin && go test -v
=== RUN   TestParseFileSpec
=== RUN   TestParseFileSpec/local_file
=== RUN   TestParseFileSpec/pod_file
=== RUN   TestParseFileSpec/pod_file_with_namespace
=== RUN   TestParseFileSpec/file_path_with_colon
--- PASS: TestParseFileSpec (0.00s)
    --- PASS: TestParseFileSpec/local_file (0.00s)
    --- PASS: TestParseFileSpec/pod_file (0.00s)
    --- PASS: TestParseFileSpec/pod_file_with_namespace (0.00s)
    --- PASS: TestParseFileSpec/file_path_with_colon (0.00s)
=== RUN   TestValidateLocalDestination
=== RUN   TestValidateLocalDestination/existing_directory
=== RUN   TestValidateLocalDestination/existing_file
=== RUN   TestValidateLocalDestination/new_file_in_existing_dir
=== RUN   TestValidateLocalDestination/parent_does_not_exist
--- PASS: TestValidateLocalDestination (0.00s)
    --- PASS: TestValidateLocalDestination/existing_directory (0.00s)
    --- PASS: TestValidateLocalDestination/existing_file (0.00s)
    --- PASS: TestValidateLocalDestination/new_file_in_existing_dir (0.00s)
    --- PASS: TestValidateLocalDestination/parent_does_not_exist (0.00s)
=== RUN   TestExtractTarSingleFile
--- PASS: TestExtractTarSingleFile (0.00s)
=== RUN   TestExtractTarDirectory
--- PASS: TestExtractTarDirectory (0.00s)
=== RUN   TestExtractTarPathTraversal
--- PASS: TestExtractTarPathTraversal (0.00s)
=== RUN   TestExtractTarSymlinkSkipped
--- PASS: TestExtractTarSymlinkSkipped (0.00s)
=== RUN   TestExtractTarValidDoubleDotFilename
--- PASS: TestExtractTarValidDoubleDotFilename (0.00s)
=== RUN   TestRunWithArgsValidation
=== RUN   TestRunWithArgsValidation/local_to_pod_-_not_supported
=== RUN   TestRunWithArgsValidation/pod_to_pod_-_not_supported
=== RUN   TestRunWithArgsValidation/local_to_local_-_source_must_be_pod
=== RUN   TestRunWithArgsValidation/empty_pod_path
--- PASS: TestRunWithArgsValidation (0.00s)
    --- PASS: TestRunWithArgsValidation/local_to_pod_-_not_supported (0.00s)
    --- PASS: TestRunWithArgsValidation/pod_to_pod_-_not_supported (0.00s)
    --- PASS: TestRunWithArgsValidation/local_to_local_-_source_must_be_pod (0.00s)
    --- PASS: TestRunWithArgsValidation/empty_pod_path (0.00s)
=== RUN   TestExtractRemotePath
=== RUN   TestExtractRemotePath/standard_tar_error
=== RUN   TestExtractRemotePath/with_prefix
=== RUN   TestExtractRemotePath/no_match
=== RUN   TestExtractRemotePath/empty
--- PASS: TestExtractRemotePath (0.00s)
    --- PASS: TestExtractRemotePath/standard_tar_error (0.00s)
    --- PASS: TestExtractRemotePath/with_prefix (0.00s)
    --- PASS: TestExtractRemotePath/no_match (0.00s)
    --- PASS: TestExtractRemotePath/empty (0.00s)
=== RUN   TestValidateCopySpecs
=== RUN   TestValidateCopySpecs/valid_pod_to_local
=== RUN   TestValidateCopySpecs/local_to_pod_blocked
=== RUN   TestValidateCopySpecs/pod_to_pod_blocked
=== RUN   TestValidateCopySpecs/empty_remote_path
--- PASS: TestValidateCopySpecs (0.00s)
    --- PASS: TestValidateCopySpecs/valid_pod_to_local (0.00s)
    --- PASS: TestValidateCopySpecs/local_to_pod_blocked (0.00s)
    --- PASS: TestValidateCopySpecs/pod_to_pod_blocked (0.00s)
    --- PASS: TestValidateCopySpecs/empty_remote_path (0.00s)
PASS
ok      github.com/adyen/kubectl-rexec/plugin   0.639s
```
```bash
❯ cd rexec/server && go test -v
=== RUN   TestExecHandlerUnsupportedContentType
--- PASS: TestExecHandlerUnsupportedContentType (0.00s)
=== RUN   TestExecHandlerBadJSON
--- PASS: TestExecHandlerBadJSON (0.00s)
=== RUN   TestExecHandlerAllowsNonExecKinds
--- PASS: TestExecHandlerAllowsNonExecKinds (0.00s)
=== RUN   TestExecHandlerBypassedUser
--- PASS: TestExecHandlerBypassedUser (0.00s)
=== RUN   TestExecHandlerSecretSauce
--- PASS: TestExecHandlerSecretSauce (0.00s)
=== RUN   TestExecHandlerExecDenied
--- PASS: TestExecHandlerExecDenied (0.00s)
=== RUN   TestCanPassBypassUser
--- PASS: TestCanPassBypassUser (0.00s)
=== RUN   TestCanPassSecretSauceMatch
--- PASS: TestCanPassSecretSauceMatch (0.00s)
=== RUN   TestCanPassNoMatch
--- PASS: TestCanPassNoMatch (0.00s)
=== RUN   TestWaitForListenerReady
--- PASS: TestWaitForListenerReady (0.00s)
=== RUN   TestRexecHandlerMissingUser
--- PASS: TestRexecHandlerMissingUser (0.00s)
PASS
ok      github.com/adyen/kubectl-rexec/rexec/server     0.353s
```

## Manual Testing

### Setup Test Environment
```bash
# 1. Create Kind cluster
kind create cluster --name rexec-test --image kindest/node:v1.30.0

# 2. Build and load image
docker build -t kubectl-rexec:test .
kind load docker-image kubectl-rexec:test --name rexec-test

# 3. Deploy with test image
cd manifests
kustomize edit set image ghcr.io/adyen/kubectl-rexec:latest=kubectl-rexec:test
kubectl apply -k . --context kind-rexec-test

# 4. Build plugin
go build -o kubectl-rexec main.go
chmod +x kubectl-rexec

# 5. Create test pod
kubectl run test-pod --image=ubuntu:22.04 -- sleep 3600
kubectl wait --for=condition=ready pod/test-pod --timeout=60s
```

### Test Cases

#### 1. Basic Exec
```bash
./kubectl-rexec exec test-pod -- echo "hello"
hello

kubectl -n kube-system logs -l app=rexec --tail=5
{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"echo hello","time":"2026-01-23T14:42:19Z"}
```

#### 2. File Download
```bash
./kubectl-rexec exec test-pod -- sh -c 'echo "from pod" > /tmp/download.txt'
./kubectl-rexec cp test-pod:/tmp/download.txt /tmp/download.txt
Copied test-pod:/tmp/download.txt to /tmp/download.txt

cat /tmp/download.txt
from pod
```

#### 3. Directory Download
```bash
./kubectl-rexec exec test-pod -- sh -c 'mkdir -p /tmp/testdir/sub && echo "file1" > /tmp/testdir/file1.txt && echo "file2" > /tmp/testdir/sub/file2.txt'
./kubectl-rexec cp test-pod:/tmp/testdir /tmp/downloaded
Copied test-pod:/tmp/testdir to /tmp/downloaded

ls -R /tmp/downloaded

file1.txt sub

/tmp/downloaded/sub:
file2.txt
```

#### 4. Multi-Container Pod
```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: multi-pod
spec:
  containers:
  - name: c1
    image: ubuntu:22.04
    command: ["sleep", "3600"]
  - name: c2
    image: ubuntu:22.04
    command: ["sleep", "3600"]
EOF

kubectl wait --for=condition=ready pod/multi-pod --timeout=60s
pod/multi-pod condition met

./kubectl-rexec exec multi-pod -c c2 -- sh -c 'echo "from c2" > /tmp/test.txt'
./kubectl-rexec cp multi-pod:/tmp/test.txt /tmp/from-c2.txt -c c2
Copied multi-pod:/tmp/test.txt to /tmp/from-c2.txt

cat /tmp/from-c2.txt
from c2
```

#### 5. Upload Blocked (Security)
```bash
./kubectl-rexec cp /tmp/local-file.txt test-pod:/tmp/dest.txt
error: copying to pods is not supported for security reasons; only pod to local copy is allowed
```

### Audit Logs
```bash
kubectl -n kube-system logs -l app=rexec --tail=5

{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"tar cf - -C /tmp -- download.txt","time":"2026-01-23T14:43:04Z"}
{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"sh -c mkdir -p /tmp/testdir/sub && echo \"file1\" > /tmp/testdir/file1.txt && echo \"file2\" > /tmp/testdir/sub/file2.txt","time":"2026-01-23T14:43:30Z"}
{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"tar cf - -C /tmp -- testdir","time":"2026-01-23T14:43:34Z"}
{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"sh -c echo \"from c2\" > /tmp/test.txt","time":"2026-01-23T14:44:29Z"}
{"level":"info","facility":"audit","user":"kubernetes-admin","session":"oneoff","command":"tar cf - -C /tmp -- test.txt","time":"2026-01-23T14:44:34Z"}
```

### Cleanup
```bash
kubectl delete pod test-pod multi-pod
kind delete cluster --name rexec-test
rm -f /tmp/download.txt /tmp/from-c2.txt
rm -rf /tmp/downloaded
```

## Fixed issue:

As mentioned we are introducing new feature so nothing to be fixed, the idea is to implement kubectl cp using rexec.
