### PR TITLE
Make Init() testable and fix r.WithContext silent bug

### DIFF
--- a/rexec/server/config.go
+++ b/rexec/server/config.go
@@ -9,6 +9,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var (
+	caPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	exitFn    = os.Exit // to be able to override in the tests
+)
+
 var token string
 var proxyMap map[string]bool
 var userMap map[string]string
@@ -37,15 +43,19 @@ func Init() {
 	auditLogger = zerolog.New(os.Stdout).With().Timestamp().Str("facility", "audit").Logger().Level(auditLevel)
 	SysLogger = zerolog.New(os.Stdout).With().Timestamp().Str("facility", "sys").Logger().Level(sysLevel)
 
-	rawCaCert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	rawCaCert, err := os.ReadFile(caPath)
 	if err != nil {
-		SysLogger.Fatal().Err(err)
+		SysLogger.Error().Err(err).Msg("failed to read the CA certificate")
+		exitFn(1)
+		return
 	}
 	CAPool = x509.NewCertPool()
 	CAPool.AppendCertsFromPEM(rawCaCert)
-	rawToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	rawToken, err := os.ReadFile(tokenPath)
 	if err != nil {
-		SysLogger.Fatal().Err(err)
+		SysLogger.Error().Err(err).Msg("failed to read the service account token")
+		exitFn(1)
+		return
 	}
 	token = string(rawToken)
 	proxyMap = make(map[string]bool)
@@ -59,7 +69,9 @@ func Init() {
 	if SecretSauce != "" {
 		_, err = uuid.Parse(SecretSauce)
 		if err != nil {
-			SysLogger.Fatal().Err(err)
+			SysLogger.Error().Err(err).Msg("SecretSauce does not contain a valid UUID")
+			exitFn(1)
+			return
 		}
 	}
 	if MaxStokesPerLine == 0 {

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -136,7 +136,7 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 		mapSync.Unlock()
 
 		// we set the previously generated context to the request
-		r.WithContext(ctx)
+		r = r.WithContext(ctx)
 
 		// Log initial command as an audit event
 		// with session id

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -230,6 +231,99 @@ func TestWaitForListenerReady(t *testing.T) {
 	}
 	if time.Since(start) > time.Second {
 		t.Fatalf("waitForListener returned too slowly")
+	}
+}
+
+// initCleanup saves all package-level state that Init modifies and restores it after the test.
+func initCleanup(t *testing.T) {
+	t.Helper()
+	oldCAPath, oldTokenPath := caPath, tokenPath
+	oldSauce := SecretSauce
+	oldExitFn := exitFn
+	t.Cleanup(func() {
+		caPath, tokenPath = oldCAPath, oldTokenPath
+		SecretSauce = oldSauce
+		exitFn = oldExitFn
+	})
+}
+
+func TestInitMissingCA(t *testing.T) {
+	initCleanup(t)
+
+	dir := t.TempDir()
+	tf, err := os.CreateTemp(dir, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tf.WriteString("token-123")
+	tf.Close()
+
+	caPath = "/invalid/ca.crt"
+	tokenPath = tf.Name()
+	SecretSauce = ""
+
+	exited := false
+	exitFn = func(int) { exited = true }
+
+	Init()
+
+	if !exited {
+		t.Fatal("expected fatal exit on missing CA cert, got none")
+	}
+}
+
+func TestInitMissingToken(t *testing.T) {
+	initCleanup(t)
+
+	dir := t.TempDir()
+	cf, err := os.CreateTemp(dir, "ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf.Close()
+
+	caPath = cf.Name()
+	tokenPath = "/invalid/token-123"
+	SecretSauce = ""
+
+	exited := false
+	exitFn = func(int) { exited = true }
+
+	Init()
+
+	if !exited {
+		t.Fatal("expected fatal exit on missing token, got none")
+	}
+}
+
+func TestInitInvalidSecretSauce(t *testing.T) {
+	initCleanup(t)
+
+	dir := t.TempDir()
+	cf, err := os.CreateTemp(dir, "ca.crt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf.Close()
+
+	tf, err := os.CreateTemp(dir, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tf.WriteString("token-123")
+	tf.Close()
+
+	caPath = cf.Name()
+	tokenPath = tf.Name()
+	SecretSauce = "not-an-uuid"
+
+	exited := false
+	exitFn = func(int) { exited = true }
+
+	Init()
+
+	if !exited {
+		t.Fatal("expected fatal exit on invalid SecretSauce, got none")
 	}
 }
 


### PR DESCRIPTION
## Summary

Init() relied on hardcoded file paths and called os.Exit directly, which made it impossible to test error paths without the process actually exiting. This PR extracts those into package-level variables so tests can override them, and replaces SysLogger.Fatal() calls with SysLogger.Error() + exitFn(1) + return to allow the exit to be intercepted.

It also fixes a silent bug in rexecHandler where the return value of r.WithContext(ctx) was discarded, meaning the context was never actually attached to the request.

## Tested scenarios

Init() error paths are now covered by unit tests:
* Missing CA certificate triggers exit
* Missing service account token triggers exit
* Invalid SecretSauce (non-UUID) triggers exit

The r.WithContext fix is covered by the existing handler tests, which now exercise the corrected code path.

## Unit Testing
```bash
[claudio@macbook:~/Projects/kubectl-rexec]% go test ./rexec/server/... -run "TestInitMissingCA|TestInitMissingToken|TestInitInvalidSecretSauce" -v
=== RUN   TestInitMissingCA
--- PASS: TestInitMissingCA (0.00s)
=== RUN   TestInitMissingToken
--- PASS: TestInitMissingToken (0.00s)
=== RUN   TestInitInvalidSecretSauce
--- PASS: TestInitInvalidSecretSauce (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/rexec/server	(cached)
[claudio@macbook:~/Projects/kubectl-rexec]%
```
```bash
[claudio@macbook:~/Projects/kubectl-rexec]% go test ./rexec/server/... -v
=== RUN   TestExecHandlerUnsupportedContentType
--- PASS: TestExecHandlerUnsupportedContentType (0.00s)
=== RUN   TestExecHandlerBadJSON
--- PASS: TestExecHandlerBadJSON (0.00s)
=== RUN   TestExecHandlerAllowsNonExecKinds
--- PASS: TestExecHandlerAllowsNonExecKinds (0.00s)
=== RUN   TestExecHandlerBypassedUser
--- PASS: TestExecHandlerBypassedUser (0.00s)
=== RUN   TestExecHandlerSecretSauce
--- PASS: TestExecHandlerSecretSauce (0.00s)
=== RUN   TestExecHandlerExecDenied
--- PASS: TestExecHandlerExecDenied (0.00s)
=== RUN   TestCanPassBypassUser
--- PASS: TestCanPassBypassUser (0.00s)
=== RUN   TestCanPassSecretSauceMatch
--- PASS: TestCanPassSecretSauceMatch (0.00s)
=== RUN   TestCanPassNoMatch
--- PASS: TestCanPassNoMatch (0.00s)
=== RUN   TestWaitForListenerReady
--- PASS: TestWaitForListenerReady (0.00s)
=== RUN   TestInitMissingCA
--- PASS: TestInitMissingCA (0.00s)
=== RUN   TestInitMissingToken
--- PASS: TestInitMissingToken (0.00s)
=== RUN   TestInitInvalidSecretSauce
--- PASS: TestInitInvalidSecretSauce (0.00s)
=== RUN   TestRexecHandlerMissingUser
--- PASS: TestRexecHandlerMissingUser (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/rexec/server	(cached)
[claudio@macbook:~/Projects/kubectl-rexec]%
```