### PR TITLE
Fix stale service account token causing 401s after token rotation

### DIFF
--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -55,7 +56,16 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	r.Header.Add("Kubectl-Command", "kubectl exec")
 
 	// adding the service account token we are using for impersonating
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Re-read token from disk on every request so we pick up kubelet's
+	// projected token rotation instead of using a stale in-memory copy.
+	rawToken, err := os.ReadFile(tokenPath)
+	if err != nil {
+		SysLogger.Error().Err(err).Msg("failed to re-read service account token")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(httpInternalError))
+		return
+	}
+	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", string(rawToken)))
 
 	// add user to impersonation header
 	r.Header.Add("Impersonate-User", user)


### PR DESCRIPTION
## Background

howdy folks, thanks for this project. we've noticed that the rexec server reads the projected service account token [once at startup in `Init()`](https://github.com/Adyen/kubectl-rexec/blob/9901b26/rexec/server/config.go#L54-L60) and caches it for the life of the pod. 

but, k8s SA tokens have a [default lifetime of 1 hour](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) and are [rotated on disk by the kubelet](https://kubernetes.io/docs/concepts/storage/projected-volumes/#serviceaccounttoken) when they approach expiry. when the token expires, the server loses auth since it doesn't re-read the rotated one from the disk.

AIUI, [`rest.InClusterConfig()`](https://pkg.go.dev/k8s.io/client-go/rest#InClusterConfig) in client-go handles this automatically, but that would've been a bigger refactor to switch

## Changes

- Re-read the token from disk on each request in `rexecHandler` instead of using the cached copy. The file is tiny (~1KB), so hopefully the disk read doesn't impact perf too much

## Testing

deployed a version built with the patch, waited for a while, can confirm that it continues to work after 1 hour

```
bash-5.2$ kc get pods -n kube-system | grep rexec
rexec-84478b97-4s5pw                                           1/1     Running   0          6h14m
rexec-84478b97-zgprh                                           1/1     Running   0          6h14m
bash-5.2$ 
bash-5.2$ 
bash-5.2$ kubectl rexec --namespace datadog exec -it pod/datadog-agent-l4lxh -- sh
Defaulted container "agent" out of: agent, trace-agent, init-volume (init), init-config (init)
# whoami
root
# 
bash-5.2$ 
```