### PR TITLE
server: simplify tty exec proxy 

### DIFF
--- a/rexec/server/config.go
+++ b/rexec/server/config.go
@@ -25,7 +25,6 @@ type sessionInfo struct {
 }
 
 var token string
-var proxyMap map[string]bool
 var sessionMap map[string]sessionInfo
 var mapSync sync.Mutex
 var SysLogger zerolog.Logger
@@ -67,7 +66,6 @@ func Init() {
 		exitFn(1)
 		return
 	}
-	proxyMap = make(map[string]bool)
 	sessionMap = make(map[string]sessionInfo)
 	commandMap = make(map[string][]byte)
 	asyncAuditChan = make(chan asyncAudit)

--- a/rexec/server/config.go
+++ b/rexec/server/config.go
@@ -111,6 +111,10 @@ func logCommand(command, user, ctxid, namespace, pod, container, clientIP string
 	auditLogger.Info().Str("user", user).Str("session", ctxid).Str("namespace", namespace).Str("pod", pod).Str("container", container).Str("client_ip", clientIP).Str("command", command).Msg("")
 }
 
+func logSessionEvent(event, user, ctxid, namespace, pod, container, clientIP string) {
+	auditLogger.Info().Str("event", event).Str("user", user).Str("session", ctxid).Str("namespace", namespace).Str("pod", pod).Str("container", container).Str("client_ip", clientIP).Msg("")
+}
+
 var httpSpec = `
 {
   "kind": "APIResourceList",

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -97,86 +95,26 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	initialCommand, needsRecording, container := parseParams(params)
 	clientIP := getIP(r)
 
+	apiServerURL, _ := url.Parse("https://" + net.JoinHostPort(apiServerHost, "443"))
+	proxy := httputil.NewSingleHostReverseProxy(apiServerURL)
+	proxy.FlushInterval = -1
+	cmd := strings.Join(initialCommand, " ")
+
 	if !needsRecording {
-		// if we dont need any recording, we just pass the request back to the kube apiserver
-		url, _ := url.Parse("https://kubernetes.default.svc.cluster.local:443")
-		proxy := httputil.NewSingleHostReverseProxy(url)
-
-		proxy.Transport = &http.Transport{
-			DisableKeepAlives:  true,
-			DisableCompression: true,
-			TLSClientConfig: &tls.Config{
-				RootCAs: CAPool,
-			},
-		}
-
-		// Log initial command as an audit event
-		// as oneoff, since we dont do tty so there
-		// wont be a recording and a session id
-		logCommand(strings.Join(initialCommand, " "), user, "oneoff", namespace, pod, container, clientIP)
-
-		proxy.FlushInterval = -1
-
+		proxy.Transport = apiServerTransport()
+		logCommand(cmd, user, "oneoff", namespace, pod, container, clientIP)
 		proxy.ServeHTTP(w, r)
-	} else {
-		// in the case of recording we will pass the request through a tcp proxy to make it easier
-		// to actually monitor what is being typed in to the shell
-
-		// we begin to generate a uuid for the session and we set it as the id of a context
-		// we will use this id to keep track what use the session belongs to
-		ctxid := uuid.New().String()
-		ctx := context.WithValue(r.Context(), "sessionID", ctxid)
-
-		// we save the session id into a map with the user's identity
-		// the namespace and pod are also saved for easier lookup
-		mapSync.Lock()
-		sessionMap[ctxid] = sessionInfo{
-			User:      user,
-			NameSpace: namespace,
-			Pod:       pod,
-			Container: container,
-			ClientIP:  clientIP,
-		}
-		mapSync.Unlock()
-
-		// we set the previously generated context to the request
-		r = r.WithContext(ctx)
-
-		// Log initial command as an audit event
-		// with session id
-		logCommand(strings.Join(initialCommand, " "), user, ctxid, namespace, pod, container, clientIP)
-
-		// we start up a tcp forwarder for the session
-		go tcpForwarder(ctx)
-
-		// we need to wait a bit until the listener is actually there
-		// probably there are 10 more sophisticated ways to do this
-		// but it is not important now
-		err = waitForListener(ctxid)
-		if err != nil {
-			SysLogger.Error().Err(err).Msg("waiting for listener")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(httpInternalError))
-			return
-		}
-
-		// url does not really matter we are going through the socket anyway
-		url, _ := url.Parse("http://localhost:8080")
-		proxy := httputil.NewSingleHostReverseProxy(url)
-
-		proxy.Transport = &http.Transport{
-			DisableKeepAlives:  true,
-			DisableCompression: true,
-			// we are forcing the reverse proxy to go through our socket
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return net.Dial("unix", fmt.Sprintf("/%s", ctxid))
-			},
-		}
-
-		proxy.FlushInterval = -1
-
-		proxy.ServeHTTP(w, r)
+		return
 	}
+
+	// tty exec audit keystrokes on tls conn see tcplogger
+	ctxid := uuid.New().String()
+	registerSession(ctxid, user, namespace, pod, container, clientIP)
+	defer endSession(ctxid)
+
+	logCommand(cmd, user, ctxid, namespace, pod, container, clientIP)
+	proxy.Transport = auditedAPIServerTransport(ctxid)
+	proxy.ServeHTTP(w, r)
 }
 
 func ensureValidToken() error {
@@ -257,26 +195,6 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
-}
-
-// waitForListener is checking whether the tcp forwarder
-// is ready or not, if it is not there after 5 secs
-// it bails
-func waitForListener(listener string) error {
-	// again, super lazy but it is fine for now
-	for i := 0; i < 5; i++ {
-		isSocketReady := false
-		mapSync.Lock()
-		isSocketReady = proxyMap[listener]
-		mapSync.Unlock()
-		if isSocketReady {
-			SysLogger.Debug().Msgf("socket became ready on try %d", i)
-			return nil
-		}
-		SysLogger.Debug().Msgf("waiting for socket on try %d", i)
-		time.Sleep(1 * time.Second)
-	}
-	return errors.New("socket was not ready in time")
 }
 
 // canPass checks whether the exec request is allowed

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -208,29 +207,6 @@ func TestCanPassNoMatch(t *testing.T) {
 		"secret-sauce": {"the-wrong-sauce"}})
 	if canPass(rv) {
 		t.Fatal("expected canPass false when neither bypass nor sauce matches")
-	}
-}
-
-// --- waitForListener unit test ---
-
-func TestWaitForListenerReady(t *testing.T) {
-	// Save/restore shared map
-	oldProxyMap := proxyMap
-	t.Cleanup(func() { proxyMap = oldProxyMap })
-
-	// Use a fresh map for isolation
-	proxyMap = map[string]bool{}
-
-	// Mark ready before call so it should return quickly
-	id := "session-123"
-	proxyMap[id] = true
-
-	start := time.Now()
-	if err := waitForListener(id); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if time.Since(start) > time.Second {
-		t.Fatalf("waitForListener returned too slowly")
 	}
 }
 

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -63,16 +63,22 @@ func registerSession(ctxid, user, namespace, pod, container, clientIP string) {
 		User: user, NameSpace: namespace, Pod: pod, Container: container, ClientIP: clientIP,
 	}
 	mapSync.Unlock()
+	logSessionEvent("session_start", user, ctxid, namespace, pod, container, clientIP)
 }
 
 func endSession(ctxid string) {
 	mapSync.Lock()
+	info, ok := sessionMap[ctxid]
 	delete(sessionMap, ctxid)
 	mapSync.Unlock()
 
 	commandSync.Lock()
 	delete(commandMap, ctxid)
 	commandSync.Unlock()
+
+	if ok {
+		logSessionEvent("session_end", info.User, ctxid, info.NameSpace, info.Pod, info.Container, info.ClientIP)
+	}
 }
 
 // tcplogger is on client to apiserver websocket direction

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -5,62 +5,68 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"net"
-	"os"
+	"net/http"
 	"strings"
 
 	"github.com/rs/zerolog"
 )
 
-const (
-	targetAddress = "kubernetes.default.svc.cluster.local:443"
-)
+const apiServerHost = "kubernetes.default.svc.cluster.local"
 
-func tcpForwarder(ctx context.Context) {
-	lc := net.ListenConfig{}
+func apiServerTLSConfig() *tls.Config {
+	return &tls.Config{
+		RootCAs:    CAPool,
+		ServerName: apiServerHost,
+	}
+}
 
-	ctxid := ctx.Value("sessionID").(string)
-	socketPath := fmt.Sprintf("/%s", ctxid)
+func baseAPIServerTransport() *http.Transport {
+	return &http.Transport{
+		DisableKeepAlives:  true,
+		DisableCompression: true,
+	}
+}
 
-	// we setup a unix listener for the specific session
-	listener, err := lc.Listen(ctx, "unix", socketPath)
+// non-tty exec goes straight to apiserver tls without keystroke logging
+func apiServerTransport() *http.Transport {
+	tr := baseAPIServerTransport()
+	tr.TLSClientConfig = apiServerTLSConfig()
+	return tr
+}
+
+// tty exec uses tls conn wrapped in tcplogger so we can audit keystrokes
+func auditedAPIServerTransport(sessionID string) *http.Transport {
+	tr := baseAPIServerTransport()
+	tr.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialAuditedConn(ctx, sessionID)
+	}
+	return tr
+}
+
+func dialAuditedConn(ctx context.Context, sessionID string) (net.Conn, error) {
+	raw, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(apiServerHost, "443"))
 	if err != nil {
-		SysLogger.Error().Err(err).Msgf("failed to start listener for %s", ctxid)
-		return
+		return nil, err
 	}
-	defer listener.Close()
+	tlsConn := tls.Client(raw, apiServerTLSConfig())
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		raw.Close()
+		return nil, err
+	}
+	return &TCPLogger{Conn: tlsConn, ctxid: sessionID}, nil
+}
 
-	SysLogger.Debug().Msgf("starting personal tcp forwarer at %s", socketPath)
-
-	// in a cheap manner we signer back that it is ready
+func registerSession(ctxid, user, namespace, pod, container, clientIP string) {
 	mapSync.Lock()
-	proxyMap[ctxid] = true
+	sessionMap[ctxid] = sessionInfo{
+		User: user, NameSpace: namespace, Pod: pod, Container: container, ClientIP: clientIP,
+	}
 	mapSync.Unlock()
-	halt := false
-	for {
-		client, err := listener.Accept()
-		if err != nil {
-			SysLogger.Error().Err(err).Msgf("failed to accept connection at %s", ctxid)
-			continue
-		}
+}
 
-		// we pass the actual tcp connection
-		go handleTcpConnection(client, ctxid)
-		select {
-		// once the http session is gone we stop the listener
-		case <-ctx.Done():
-			SysLogger.Debug().Msgf("stopping personal tcp forwarer at %s", socketPath)
-			halt = true
-		}
-		if halt {
-			break
-		}
-	}
-	// once the http session is gone, the socket and the user and proxymaps are getting cleaned up
-	os.Remove(socketPath)
+func endSession(ctxid string) {
 	mapSync.Lock()
-	delete(proxyMap, ctxid)
 	delete(sessionMap, ctxid)
 	mapSync.Unlock()
 
@@ -69,65 +75,58 @@ func tcpForwarder(ctx context.Context) {
 	commandSync.Unlock()
 }
 
-func handleTcpConnection(client net.Conn, ctxid string) {
-	// setting up the upstream connection
-	target, err := tls.Dial("tcp", targetAddress, &tls.Config{RootCAs: CAPool})
-	if err != nil {
-		SysLogger.Error().Err(err).Msgf("failed to connect to upstream at %s", ctxid)
-		client.Close()
-		return
-	}
-	defer target.Close()
-
-	// we are creating an instance of TCPLogger
-	// which implements net.conn and custom logging
-	// with the context of the user we are logging
-	// traffic for
-	tcpLogger := &TCPLogger{Conn: target, ctxid: ctxid}
-
-	// on the way toward the target we send the traffic
-	// through the tcp logger
-	go io.Copy(tcpLogger, client)
-	// on the way back however we dont want to log anything
-	io.Copy(client, target)
-	client.Close()
-}
-
+// tcplogger is on client to apiserver websocket direction
+// write path is audited read path is pass through only
 type TCPLogger struct {
 	net.Conn
 	ctxid string
 }
 
-func (t *TCPLogger) Read(b []byte) (n int, err error) {
-	n, err = t.Conn.Read(b)
-	return
-}
-
 func (t *TCPLogger) Write(b []byte) (n int, err error) {
 	n, err = t.Conn.Write(b)
 	if n > 0 {
-		// we need parse the websockter frame
-		frame, err := parseWebSocketFrame(b)
-		if err != nil {
-			SysLogger.Error().Err(err).Msg("failed to parse ws frame")
-		}
-		if frame != nil {
-			// if it is opscode 0x2 we log out
-			// activities
-			if frame.Opcode == 0x2 {
-				if auditLogger.GetLevel() == zerolog.TraceLevel {
-					stroke, err := hex.DecodeString(fmt.Sprintf("%x", frame.Payload))
-					if err != nil {
-						SysLogger.Error().Err(err).Msg("failed to parse payload")
-					}
-					auditLogger.Trace().Str("user", sessionMap[t.ctxid].User).Str("session", t.ctxid).Str("namespace", sessionMap[t.ctxid].NameSpace).Str("pod", sessionMap[t.ctxid].Pod).Str("container", sessionMap[t.ctxid].Container).Str("client_ip", sessionMap[t.ctxid].ClientIP).Str("stroke", strings.ReplaceAll(string(stroke), "\u0000", "")).Msg("")
-				}
-				asyncAuditChan <- asyncAudit{
-					ctxid: t.ctxid,
-					ascii: frame.Payload,
-				}
-			}
-		}
+		t.auditClientFrame(b[:n])
 	}
-	return
+	return n, err
+}
+
+func (t *TCPLogger) auditClientFrame(frameBytes []byte) {
+	parsed, err := parseWebSocketFrame(frameBytes)
+	if err != nil {
+		SysLogger.Error().Err(err).Msg("failed to parse ws frame")
+		return
+	}
+	// websocket opcodes we might see: 0x0 continuation 0x1 text 0x2 binary
+	// 0x8 close 0x9 ping 0xA pong
+	// kubectl exec sends terminal input as 0x2 binary only that goes to async audit
+	if parsed == nil || parsed.Opcode != 0x2 {
+		return
+	}
+
+	if auditLogger.GetLevel() == zerolog.TraceLevel {
+		t.logTraceStroke(parsed.Payload)
+	}
+	asyncAuditChan <- asyncAudit{ctxid: t.ctxid, ascii: parsed.Payload}
+}
+
+func (t *TCPLogger) logTraceStroke(payload []byte) {
+	info, ok := sessionMap[t.ctxid]
+	if !ok {
+		return
+	}
+	stroke, err := hex.DecodeString(fmt.Sprintf("%x", payload))
+	if err != nil {
+		SysLogger.Error().Err(err).Msg("failed to parse payload")
+		return
+	}
+	auditLogger.Trace().
+		Str("user", info.User).
+		Str("session", t.ctxid).
+		Str("namespace", info.NameSpace).
+		Str("pod", info.Pod).
+		Str("container", info.Container).
+		Str("client_ip", info.ClientIP).
+		// tty payload has nul bytes strip for trace log
+		Str("stroke", strings.ReplaceAll(string(stroke), "\u0000", "")).
+		Msg("")
 }

--- a/rexec/server/tcp_test.go
+++ b/rexec/server/tcp_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// fake network connection
+type stubConn struct {
+	written [][]byte
+}
+
+func (s *stubConn) Read([]byte) (int, error) { return 0, io.EOF }
+func (s *stubConn) Write(p []byte) (int, error) {
+	s.written = append(s.written, append([]byte(nil), p...))
+	return len(p), nil
+}
+func (s *stubConn) Close() error                     { return nil }
+func (s *stubConn) LocalAddr() net.Addr              { return nil }
+func (s *stubConn) RemoteAddr() net.Addr             { return nil }
+func (s *stubConn) SetDeadline(time.Time) error      { return nil }
+func (s *stubConn) SetReadDeadline(time.Time) error  { return nil }
+func (s *stubConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestAPIServerTransportsDiffer(t *testing.T) {
+	plain := apiServerTransport()
+	if plain.TLSClientConfig == nil {
+		t.Fatal("non-TTY transport must use TLSClientConfig")
+	}
+	if plain.DialTLSContext != nil {
+		t.Fatal("non-TTY transport must not set DialTLSContext")
+	}
+
+	audited := auditedAPIServerTransport("sess")
+	if audited.DialTLSContext == nil {
+		t.Fatal("TTY transport must set DialTLSContext")
+	}
+	if audited.TLSClientConfig != nil {
+		t.Fatal("TTY transport must not use TLSClientConfig (TLS is done in DialTLSContext)")
+	}
+}
+
+func TestEndSessionIdempotent(t *testing.T) {
+	oldSessionMap := sessionMap
+	oldCommandMap := commandMap
+	t.Cleanup(func() {
+		sessionMap = oldSessionMap
+		commandMap = oldCommandMap
+	})
+
+	sessionMap = map[string]sessionInfo{}
+	commandMap = map[string][]byte{}
+
+	endSession("never-existed")
+	endSession("never-existed")
+
+	id := "gone"
+	sessionMap[id] = sessionInfo{User: "bob"}
+	commandMap[id] = []byte{'x'}
+
+	endSession(id)
+	endSession(id)
+
+	if len(sessionMap) != 0 || len(commandMap) != 0 {
+		t.Fatalf("maps should be empty, sessionMap=%d commandMap=%d", len(sessionMap), len(commandMap))
+	}
+}
+
+func TestTCPLoggerWriteSkipsNonBinaryOpcode(t *testing.T) {
+	oldChan := asyncAuditChan
+	t.Cleanup(func() { asyncAuditChan = oldChan })
+
+	asyncAuditChan = make(chan asyncAudit, 1)
+	logger := &TCPLogger{Conn: &stubConn{}, ctxid: "s1"}
+
+	// FIN + text opcode 0x1, unmasked, empty payload
+	_, err := logger.Write([]byte{0x81, 0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-asyncAuditChan:
+		t.Fatal("text frame must not enqueue async audit")
+	default:
+	}
+}
+
+func TestTCPLoggerWriteStillForwardsOnParseError(t *testing.T) {
+	oldChan := asyncAuditChan
+	t.Cleanup(func() { asyncAuditChan = oldChan })
+
+	asyncAuditChan = make(chan asyncAudit, 1)
+	conn := &stubConn{}
+	logger := &TCPLogger{Conn: conn, ctxid: "s1"}
+
+	n, err := logger.Write([]byte{0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || len(conn.written) != 1 {
+		t.Fatalf("expected 1 byte forwarded, n=%d writes=%d", n, len(conn.written))
+	}
+
+	select {
+	case <-asyncAuditChan:
+		t.Fatal("invalid frame must not enqueue audit")
+	default:
+	}
+}
+
+func TestAuditedDialTLSContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tr := auditedAPIServerTransport("sess")
+	_, err := tr.DialTLSContext(ctx, "tcp", "unused")
+	if err == nil {
+		t.Fatal("expected error when context is already cancelled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This change simplify tty exec proxy path

Before tty was going through unix socket forwarder per session and waiting for listener ready. Now tty proxy dial apiserver directly and wrap the tls conn with tcplogger so we still can audit keystrokes

Also add audit lifecycle events for tty sessions it logs session_start when session begin and session_end when session finish so it looks like previous unix ready signs


## Tested scenarios
- `go test ./...`
- non tty exec on kind cluster (`kubectl rexec exec demo -- echo ok`)
- tty exec on kind cluster (`kubectl rexec exec demo -it -- sh` and then `echo hi`)

