### PR TITLE
Fix WebSocket parsing bugs

### DIFF
--- a/rexec/server/parser.go
+++ b/rexec/server/parser.go
@@ -13,9 +13,9 @@ type webSocketFrame struct {
 }
 
 // parseWebSocketFrame is for parsing websocket traffic
-func parseWebSocketFrame(data []byte) (*webSocketFrame, error) {
+func parseWebSocketFrame(data []byte) (*webSocketFrame, int, error) {
 	if len(data) < 2 {
-		return nil, errors.New("data too short to be a WebSocket frame")
+		return nil, 0, errors.New("data too short to be a WebSocket frame")
 	}
 
 	fin := data[0]&0x80 != 0
@@ -28,13 +28,13 @@ func parseWebSocketFrame(data []byte) (*webSocketFrame, error) {
 	switch payloadLen {
 	case 126:
 		if len(data) < 4 {
-			return nil, errors.New("data too short for extended payload length")
+			return nil, 0, errors.New("data too short for extended payload length")
 		}
 		payloadLen = int(binary.BigEndian.Uint16(data[2:4]))
 		offset = 4
 	case 127:
 		if len(data) < 10 {
-			return nil, errors.New("data too short for extended payload length")
+			return nil, 0, errors.New("data too short for extended payload length")
 		}
 		payloadLen = int(binary.BigEndian.Uint64(data[2:10]))
 		offset = 10
@@ -46,15 +46,21 @@ func parseWebSocketFrame(data []byte) (*webSocketFrame, error) {
 		offset += 4
 	}
 
-	var maskingKey []byte
-	if mask {
-		maskingKey = data[offset-4 : offset]
+	// offset can exceed len(data) for a masked frame whose 4 byte masking key is
+	// not fully present. So len(data)-offset would then be negative.
+	if offset > len(data) {
+		return nil, 0, errors.New("data too short for masking key")
+	}
+	if payloadLen < 0 || payloadLen > len(data)-offset {
+		return nil, 0, errors.New("data too short for declared payload length")
 	}
 
-	payload := data[offset:]
+	payload := make([]byte, payloadLen)
+	copy(payload, data[offset:offset+payloadLen])
 
 	if mask {
-		for i := 0; i < len(payload); i++ {
+		maskingKey := data[offset-4 : offset]
+		for i := range payload {
 			payload[i] ^= maskingKey[i%4]
 		}
 	}
@@ -64,5 +70,5 @@ func parseWebSocketFrame(data []byte) (*webSocketFrame, error) {
 		Opcode:  opcode,
 		Mask:    mask,
 		Payload: payload,
-	}, nil
+	}, offset + payloadLen, nil
 }

--- a/rexec/server/parser_test.go
+++ b/rexec/server/parser_test.go
@@ -118,32 +118,36 @@ func TestParseWebSocketFrame(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			original := append([]byte(nil), tt.data...)
-
-			frame, consumed, err := parseWebSocketFrame(tt.data)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got frame %+v", frame)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if frame.Opcode != tt.wantOpcode {
-				t.Errorf("opcode = %#x, want %#x", frame.Opcode, tt.wantOpcode)
-			}
-			if !bytes.Equal(frame.Payload, tt.wantPayload) {
-				t.Errorf("payload = %q, want %q", frame.Payload, tt.wantPayload)
-			}
-			if consumed != len(tt.data) {
-				t.Errorf("consumed = %d, want %d", consumed, len(tt.data))
-			}
-			if !bytes.Equal(tt.data, original) {
-				t.Errorf("input buffer was mutated: got %v, want %v", tt.data, original)
-			}
+			runParserTest(t, tt.data, tt.wantOpcode, tt.wantPayload, tt.wantErr)
 		})
+	}
+}
+
+func runParserTest(t *testing.T, data []byte, wantOpcode byte, wantPayload []byte, wantErr bool) {
+	t.Parallel()
+	original := append([]byte(nil), data...)
+
+	frame, consumed, err := parseWebSocketFrame(data)
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected error, got frame %+v", frame)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if frame.Opcode != wantOpcode {
+		t.Errorf("opcode = %#x, want %#x", frame.Opcode, wantOpcode)
+	}
+	if !bytes.Equal(frame.Payload, wantPayload) {
+		t.Errorf("payload = %q, want %q", frame.Payload, wantPayload)
+	}
+	if consumed != len(data) {
+		t.Errorf("consumed = %d, want %d", consumed, len(data))
+	}
+	if !bytes.Equal(data, original) {
+		t.Errorf("input buffer was mutated: got %v, want %v", data, original)
 	}
 }
 

--- a/rexec/server/parser_test.go
+++ b/rexec/server/parser_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildFrame assembles a WebSocket frame. When mask is true the payload is
+// masked with maskKey, mirroring how a kubectl client frames terminal input.
+func buildFrame(opcode byte, payload []byte, mask bool, maskKey [4]byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(0x80 | opcode) // FIN set
+
+	n := len(payload)
+	switch {
+	case n < 126:
+		b := byte(n)
+		if mask {
+			b |= 0x80
+		}
+		buf.WriteByte(b)
+	case n < 65536:
+		b := byte(126)
+		if mask {
+			b |= 0x80
+		}
+		buf.WriteByte(b)
+		var ext [2]byte
+		binary.BigEndian.PutUint16(ext[:], uint16(n))
+		buf.Write(ext[:])
+	default:
+		b := byte(127)
+		if mask {
+			b |= 0x80
+		}
+		buf.WriteByte(b)
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(n))
+		buf.Write(ext[:])
+	}
+
+	if mask {
+		buf.Write(maskKey[:])
+		masked := make([]byte, n)
+		for i := range payload {
+			masked[i] = payload[i] ^ maskKey[i%4]
+		}
+		buf.Write(masked)
+	} else {
+		buf.Write(payload)
+	}
+
+	return buf.Bytes()
+}
+
+func TestParseWebSocketFrame(t *testing.T) {
+	key := [4]byte{0xAA, 0xBB, 0xCC, 0xDD}
+
+	tests := []struct {
+		name        string
+		data        []byte
+		wantOpcode  byte
+		wantPayload []byte
+		wantErr     bool
+	}{
+		{
+			name:        "unmasked text frame",
+			data:        buildFrame(0x1, []byte("hello"), false, key),
+			wantOpcode:  0x1,
+			wantPayload: []byte("hello"),
+		},
+		{
+			name:        "masked binary frame",
+			data:        buildFrame(0x2, []byte("ls -la"), true, key),
+			wantOpcode:  0x2,
+			wantPayload: []byte("ls -la"),
+		},
+		{
+			name:        "empty payload",
+			data:        buildFrame(0x2, []byte{}, true, key),
+			wantOpcode:  0x2,
+			wantPayload: []byte{},
+		},
+		{
+			name:        "extended 16-bit length",
+			data:        buildFrame(0x2, bytes.Repeat([]byte("a"), 300), true, key),
+			wantOpcode:  0x2,
+			wantPayload: bytes.Repeat([]byte("a"), 300),
+		},
+		{
+			name:        "extended 64-bit length",
+			data:        buildFrame(0x2, bytes.Repeat([]byte("b"), 70000), true, key),
+			wantOpcode:  0x2,
+			wantPayload: bytes.Repeat([]byte("b"), 70000),
+		},
+		{
+			name:    "too short for header",
+			data:    []byte{0x82},
+			wantErr: true,
+		},
+		{
+			name:    "truncated extended 16-bit header",
+			data:    []byte{0x82, 126, 0x00},
+			wantErr: true,
+		},
+		{
+			name:    "truncated masking key",
+			data:    []byte{0x82, 0x85, 0xAA, 0xBB}, // masked, len 5, only 2 of 4 key bytes
+			wantErr: true,
+		},
+		{
+			name:    "payload shorter than declared",
+			data:    []byte{0x82, 0x05, 'h', 'i'}, // declares 5, has 2
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			original := append([]byte(nil), tt.data...)
+
+			frame, consumed, err := parseWebSocketFrame(tt.data)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got frame %+v", frame)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if frame.Opcode != tt.wantOpcode {
+				t.Errorf("opcode = %#x, want %#x", frame.Opcode, tt.wantOpcode)
+			}
+			if !bytes.Equal(frame.Payload, tt.wantPayload) {
+				t.Errorf("payload = %q, want %q", frame.Payload, tt.wantPayload)
+			}
+			if consumed != len(tt.data) {
+				t.Errorf("consumed = %d, want %d", consumed, len(tt.data))
+			}
+			if !bytes.Equal(tt.data, original) {
+				t.Errorf("input buffer was mutated: got %v, want %v", tt.data, original)
+			}
+		})
+	}
+}
+
+func TestParseWebSocketFrameCoalesced(t *testing.T) {
+	key := [4]byte{0x01, 0x02, 0x03, 0x04}
+	first := buildFrame(0x2, []byte("echo"), true, key)
+	second := buildFrame(0x2, []byte("date"), true, key)
+	buf := append(append([]byte(nil), first...), second...)
+
+	frame1, consumed1, err := parseWebSocketFrame(buf)
+	if err != nil {
+		t.Fatalf("first frame: %v", err)
+	}
+	if !bytes.Equal(frame1.Payload, []byte("echo")) {
+		t.Fatalf("first payload = %q, want %q", frame1.Payload, "echo")
+	}
+	if consumed1 != len(first) {
+		t.Fatalf("first consumed = %d, want %d", consumed1, len(first))
+	}
+
+	frame2, consumed2, err := parseWebSocketFrame(buf[consumed1:])
+	if err != nil {
+		t.Fatalf("second frame: %v", err)
+	}
+	if !bytes.Equal(frame2.Payload, []byte("date")) {
+		t.Fatalf("second payload = %q, want %q", frame2.Payload, "date")
+	}
+	if consumed2 != len(second) {
+		t.Fatalf("second consumed = %d, want %d", consumed2, len(second))
+	}
+}

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -95,22 +95,29 @@ func (t *TCPLogger) Write(b []byte) (n int, err error) {
 }
 
 func (t *TCPLogger) auditClientFrame(frameBytes []byte) {
-	parsed, err := parseWebSocketFrame(frameBytes)
-	if err != nil {
-		SysLogger.Error().Err(err).Msg("failed to parse ws frame")
-		return
-	}
-	// websocket opcodes we might see: 0x0 continuation 0x1 text 0x2 binary
-	// 0x8 close 0x9 ping 0xA pong
-	// kubectl exec sends terminal input as 0x2 binary only that goes to async audit
-	if parsed == nil || parsed.Opcode != 0x2 {
-		return
-	}
+    // a single write operation may contain multiple combined frames. Continue
+    // parsing until the entire buffer has been processed to ensure no keystrokes
+    // are omitted from the audit log.
+	for len(frameBytes) > 0 {
+		parsed, consumed, err := parseWebSocketFrame(frameBytes)
+		if err != nil {
+			SysLogger.Error().Err(err).Msg("failed to parse ws frame")
+			return
+		}
+		frameBytes = frameBytes[consumed:]
 
-	if auditLogger.GetLevel() == zerolog.TraceLevel {
-		t.logTraceStroke(parsed.Payload)
+		// websocket opcodes we might see: 0x0 continuation 0x1 text 0x2 binary
+		// 0x8 close 0x9 ping 0xA pong
+		// kubectl exec sends terminal input as 0x2 binary only that goes to async audit
+		if parsed.Opcode != 0x2 {
+			continue
+		}
+
+		if auditLogger.GetLevel() == zerolog.TraceLevel {
+			t.logTraceStroke(parsed.Payload)
+		}
+		asyncAuditChan <- asyncAudit{ctxid: t.ctxid, ascii: parsed.Payload}
 	}
-	asyncAuditChan <- asyncAudit{ctxid: t.ctxid, ascii: parsed.Payload}
 }
 
 func (t *TCPLogger) logTraceStroke(payload []byte) {

--- a/rexec/server/tcp_test.go
+++ b/rexec/server/tcp_test.go
@@ -90,6 +90,34 @@ func TestTCPLoggerWriteSkipsNonBinaryOpcode(t *testing.T) {
 	}
 }
 
+func TestTCPLoggerWriteAuditsCoalescedFrames(t *testing.T) {
+	oldChan := asyncAuditChan
+	t.Cleanup(func() { asyncAuditChan = oldChan })
+
+	asyncAuditChan = make(chan asyncAudit, 4)
+	logger := &TCPLogger{Conn: &stubConn{}, ctxid: "s1"}
+
+	key := [4]byte{0x01, 0x02, 0x03, 0x04}
+	first := buildFrame(0x2, []byte("echo"), true, key)
+	second := buildFrame(0x2, []byte("date"), true, key)
+
+	if _, err := logger.Write(append(append([]byte(nil), first...), second...)); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"echo", "date"}
+	for _, w := range want {
+		select {
+		case got := <-asyncAuditChan:
+			if string(got.ascii) != w {
+				t.Fatalf("audit payload = %q, want %q", got.ascii, w)
+			}
+		default:
+			t.Fatalf("expected coalesced frame %q to be enqueued", w)
+		}
+	}
+}
+
 func TestTCPLoggerWriteStillForwardsOnParseError(t *testing.T) {
 	oldChan := asyncAuditChan
 	t.Cleanup(func() { asyncAuditChan = oldChan })


### PR DESCRIPTION
## Summary

The `parseWebSocketFrame` in `rexec/server/parser.go` ignores the declared payload length and slices to the end of the input buffer (data[offset:]), which made it impossible to parse combined WebSocket frames sequentially and led to silent keystroke loss in the audit log. It also mutates the caller's transport buffer in-place during unmasking, risking buffer contamination. The code is reachable from the TTY audit path via TCPLogger.Write -> auditClientFrame -> parseWebSocketFrame.

This PR solves these issues by using the parsed payload length for extraction, looping over the input buffer in auditClientFrame() to process all combined frames, copying the payload into a fresh slice before unmasking, and adding robust bounds checking to prevent out-of-bounds panics on truncated or malformed frames.

## Tested scenarios

The parser's correctness and safety are now fully covered by unit tests:

* Header and length parsing:
  - Single unmasked text frames are parsed correctly.
  - Single masked binary frames are parsed correctly.
  - Empty payloads are handled without errors.
  - Extended payload lengths (16-bit and 64-bit) are correctly processed.
* Malformed and truncated inputs (error paths):
  - Inputs too short for the basic header trigger an error.
  - Truncated extended headers trigger an error.
  - Truncated masking keys trigger an error.
  - Payload size shorter than the declared length triggers an error.
* Combining and buffer handling:
  - Multiple back-to-back combined frames are parsed correctly in sequence.
  - TCPLogger.Write correctly parses and logs combined frames sequentially.

## Unit Testing
```bash
[claudio@macbook:~/Projects/kubectl-rexec-fork]% go test -v -race ./...
?   	github.com/adyen/kubectl-rexec	[no test files]
=== RUN   TestParseFileSpec
=== RUN   TestParseFileSpec/local_file
=== RUN   TestParseFileSpec/pod_file
=== RUN   TestParseFileSpec/pod_with_namespace
=== RUN   TestParseFileSpec/path_with_colon
--- PASS: TestParseFileSpec (0.00s)
    --- PASS: TestParseFileSpec/local_file (0.00s)
    --- PASS: TestParseFileSpec/pod_file (0.00s)
    --- PASS: TestParseFileSpec/pod_with_namespace (0.00s)
    --- PASS: TestParseFileSpec/path_with_colon (0.00s)
=== RUN   TestValidateLocalDestination
=== RUN   TestValidateLocalDestination/existing_dir
=== RUN   TestValidateLocalDestination/existing_file
=== RUN   TestValidateLocalDestination/new_file_in_dir
=== RUN   TestValidateLocalDestination/parent_missing
--- PASS: TestValidateLocalDestination (0.00s)
    --- PASS: TestValidateLocalDestination/existing_dir (0.00s)
    --- PASS: TestValidateLocalDestination/existing_file (0.00s)
    --- PASS: TestValidateLocalDestination/new_file_in_dir (0.00s)
    --- PASS: TestValidateLocalDestination/parent_missing (0.00s)
=== RUN   TestExtractTarSingleFile
--- PASS: TestExtractTarSingleFile (0.00s)
=== RUN   TestExtractTarDirectory
--- PASS: TestExtractTarDirectory (0.00s)
=== RUN   TestExtractTarRenameDirectory
--- PASS: TestExtractTarRenameDirectory (0.00s)
=== RUN   TestExtractTarLinkTypesSkipped
=== RUN   TestExtractTarLinkTypesSkipped/symlink
=== RUN   TestExtractTarLinkTypesSkipped/hardlink
--- PASS: TestExtractTarLinkTypesSkipped (0.00s)
    --- PASS: TestExtractTarLinkTypesSkipped/symlink (0.00s)
    --- PASS: TestExtractTarLinkTypesSkipped/hardlink (0.00s)
=== RUN   TestExtractTarPathTraversal
--- PASS: TestExtractTarPathTraversal (0.00s)
=== RUN   TestExtractTarValidDoubleDotFileName
--- PASS: TestExtractTarValidDoubleDotFileName (0.00s)
=== RUN   TestExtractTarValidDoubleDotDirectoryName
--- PASS: TestExtractTarValidDoubleDotDirectoryName (0.00s)
=== RUN   TestRunWithArgsValidation
=== RUN   TestRunWithArgsValidation/upload_blocked
=== RUN   TestRunWithArgsValidation/pod_to_pod_blocked
=== RUN   TestRunWithArgsValidation/local_to_local
=== RUN   TestRunWithArgsValidation/empty_path
--- PASS: TestRunWithArgsValidation (0.00s)
    --- PASS: TestRunWithArgsValidation/upload_blocked (0.00s)
    --- PASS: TestRunWithArgsValidation/pod_to_pod_blocked (0.00s)
    --- PASS: TestRunWithArgsValidation/local_to_local (0.00s)
    --- PASS: TestRunWithArgsValidation/empty_path (0.00s)
=== RUN   TestValidateCopySpecs
=== RUN   TestValidateCopySpecs/valid
=== RUN   TestValidateCopySpecs/upload
=== RUN   TestValidateCopySpecs/pod_to_pod
=== RUN   TestValidateCopySpecs/empty_path
--- PASS: TestValidateCopySpecs (0.00s)
    --- PASS: TestValidateCopySpecs/valid (0.00s)
    --- PASS: TestValidateCopySpecs/upload (0.00s)
    --- PASS: TestValidateCopySpecs/pod_to_pod (0.00s)
    --- PASS: TestValidateCopySpecs/empty_path (0.00s)
=== RUN   TestComputeSafeTarget
=== RUN   TestComputeSafeTarget/normal_file
=== RUN   TestComputeSafeTarget/bad_path
=== RUN   TestComputeSafeTarget/absolute_path
=== RUN   TestComputeSafeTarget/double_dot
--- PASS: TestComputeSafeTarget (0.00s)
    --- PASS: TestComputeSafeTarget/normal_file (0.00s)
    --- PASS: TestComputeSafeTarget/bad_path (0.00s)
    --- PASS: TestComputeSafeTarget/absolute_path (0.00s)
    --- PASS: TestComputeSafeTarget/double_dot (0.00s)
=== RUN   TestProcessTarEntry
=== RUN   TestProcessTarEntry/regular_file
=== RUN   TestProcessTarEntry/directory
--- PASS: TestProcessTarEntry (0.00s)
    --- PASS: TestProcessTarEntry/regular_file (0.00s)
    --- PASS: TestProcessTarEntry/directory (0.00s)
=== RUN   TestProcessTarEntryUnsupportedTypes
=== RUN   TestProcessTarEntryUnsupportedTypes/block_device
=== RUN   TestProcessTarEntryUnsupportedTypes/char_device
=== RUN   TestProcessTarEntryUnsupportedTypes/fifo
--- PASS: TestProcessTarEntryUnsupportedTypes (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/block_device (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/char_device (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/fifo (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/plugin	(cached)
?   	github.com/adyen/kubectl-rexec/rexec	[no test files]
=== RUN   TestInitAPIServer
--- PASS: TestInitAPIServer (0.00s)
=== RUN   TestInitAPIServerIPv6
--- PASS: TestInitAPIServerIPv6 (0.00s)
=== RUN   TestInitAPIServerDefaultDomain
--- PASS: TestInitAPIServerDefaultDomain (0.00s)
=== RUN   TestParseWebSocketFrame
=== RUN   TestParseWebSocketFrame/unmasked_text_frame
=== PAUSE TestParseWebSocketFrame/unmasked_text_frame
=== RUN   TestParseWebSocketFrame/masked_binary_frame
=== PAUSE TestParseWebSocketFrame/masked_binary_frame
=== RUN   TestParseWebSocketFrame/empty_payload
=== PAUSE TestParseWebSocketFrame/empty_payload
=== RUN   TestParseWebSocketFrame/extended_16-bit_length
=== PAUSE TestParseWebSocketFrame/extended_16-bit_length
=== RUN   TestParseWebSocketFrame/extended_64-bit_length
=== PAUSE TestParseWebSocketFrame/extended_64-bit_length
=== RUN   TestParseWebSocketFrame/too_short_for_header
=== PAUSE TestParseWebSocketFrame/too_short_for_header
=== RUN   TestParseWebSocketFrame/truncated_extended_16-bit_header
=== PAUSE TestParseWebSocketFrame/truncated_extended_16-bit_header
=== RUN   TestParseWebSocketFrame/truncated_masking_key
=== PAUSE TestParseWebSocketFrame/truncated_masking_key
=== RUN   TestParseWebSocketFrame/payload_shorter_than_declared
=== PAUSE TestParseWebSocketFrame/payload_shorter_than_declared
=== CONT  TestParseWebSocketFrame/masked_binary_frame
=== CONT  TestParseWebSocketFrame/truncated_masking_key
=== CONT  TestParseWebSocketFrame/empty_payload
=== CONT  TestParseWebSocketFrame/payload_shorter_than_declared
=== CONT  TestParseWebSocketFrame/extended_16-bit_length
=== CONT  TestParseWebSocketFrame/unmasked_text_frame
=== CONT  TestParseWebSocketFrame/too_short_for_header
=== CONT  TestParseWebSocketFrame/truncated_extended_16-bit_header
=== CONT  TestParseWebSocketFrame/extended_64-bit_length
--- PASS: TestParseWebSocketFrame (0.00s)
    --- PASS: TestParseWebSocketFrame/masked_binary_frame (0.00s)
    --- PASS: TestParseWebSocketFrame/truncated_masking_key (0.00s)
    --- PASS: TestParseWebSocketFrame/empty_payload (0.00s)
    --- PASS: TestParseWebSocketFrame/payload_shorter_than_declared (0.00s)
    --- PASS: TestParseWebSocketFrame/extended_16-bit_length (0.00s)
    --- PASS: TestParseWebSocketFrame/too_short_for_header (0.00s)
    --- PASS: TestParseWebSocketFrame/unmasked_text_frame (0.00s)
    --- PASS: TestParseWebSocketFrame/truncated_extended_16-bit_header (0.00s)
    --- PASS: TestParseWebSocketFrame/extended_64-bit_length (0.00s)
=== RUN   TestParseWebSocketFrameCoalesced
--- PASS: TestParseWebSocketFrameCoalesced (0.00s)
=== RUN   TestExecHandlerUnsupportedContentType
--- PASS: TestExecHandlerUnsupportedContentType (0.00s)
=== RUN   TestExecHandlerBadJSON
--- PASS: TestExecHandlerBadJSON (0.00s)
=== RUN   TestExecHandlerAllowsNonExecKinds
--- PASS: TestExecHandlerAllowsNonExecKinds (0.00s)
=== RUN   TestExecHandlerBypassedUser
--- PASS: TestExecHandlerBypassedUser (0.00s)
=== RUN   TestExecHandlerSecretSauce
--- PASS: TestExecHandlerSecretSauce (0.00s)
=== RUN   TestExecHandlerExecDenied
--- PASS: TestExecHandlerExecDenied (0.00s)
=== RUN   TestCanPassBypassUser
--- PASS: TestCanPassBypassUser (0.00s)
=== RUN   TestCanPassSecretSauceMatch
--- PASS: TestCanPassSecretSauceMatch (0.00s)
=== RUN   TestCanPassNoMatch
--- PASS: TestCanPassNoMatch (0.00s)
=== RUN   TestInitMissingCA
--- PASS: TestInitMissingCA (0.00s)
=== RUN   TestInitMissingToken
--- PASS: TestInitMissingToken (0.00s)
=== RUN   TestInitInvalidSecretSauce
--- PASS: TestInitInvalidSecretSauce (0.00s)
=== RUN   TestRexecHandlerRejectsWithoutFrontProxyCert
--- PASS: TestRexecHandlerRejectsWithoutFrontProxyCert (0.00s)
=== RUN   TestRexecHandlerRejectsDisallowedCN
--- PASS: TestRexecHandlerRejectsDisallowedCN (0.00s)
=== RUN   TestRexecHandlerMissingUser
--- PASS: TestRexecHandlerMissingUser (0.00s)
=== RUN   TestVerifiedFrontProxy
--- PASS: TestVerifiedFrontProxy (0.00s)
=== RUN   TestAPIServerTransportsDiffer
--- PASS: TestAPIServerTransportsDiffer (0.00s)
=== RUN   TestEndSessionIdempotent
{"level":"info","facility":"audit","event":"session_end","user":"bob","session":"gone","namespace":"","pod":"","container":"","client_ip":"","time":"2026-06-14T20:19:46+01:00"}
--- PASS: TestEndSessionIdempotent (0.00s)
=== RUN   TestTCPLoggerWriteSkipsNonBinaryOpcode
--- PASS: TestTCPLoggerWriteSkipsNonBinaryOpcode (0.00s)
=== RUN   TestTCPLoggerWriteAuditsCoalescedFrames
--- PASS: TestTCPLoggerWriteAuditsCoalescedFrames (0.00s)
=== RUN   TestTCPLoggerWriteStillForwardsOnParseError
--- PASS: TestTCPLoggerWriteStillForwardsOnParseError (0.00s)
=== RUN   TestAuditedDialTLSContextCancelled
--- PASS: TestAuditedDialTLSContextCancelled (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/rexec/server	(cached)
[claudio@macbook:~/Projects/kubectl-rexec-fork]%
```