### PR TITLE
Fix data races on sessionMap from the audit path

### DIFF
--- a/rexec/server/async.go
+++ b/rexec/server/async.go
@@ -28,7 +28,7 @@ func storeOrFlush(audit asyncAudit) {
 			commandSync.Unlock()
 		case 13:
 			commandSync.Lock()
-			logCommand(string(commandMap[audit.ctxid]), sessionMap[audit.ctxid].User, audit.ctxid, sessionMap[audit.ctxid].NameSpace, sessionMap[audit.ctxid].Pod, sessionMap[audit.ctxid].Container, sessionMap[audit.ctxid].ClientIP)
+			logCommand(string(commandMap[audit.ctxid]), audit.info.User, audit.ctxid, audit.info.NameSpace, audit.info.Pod, audit.info.Container, audit.info.ClientIP)
 			commandMap[audit.ctxid] = nil
 			commandSync.Unlock()
 		default:
@@ -36,7 +36,7 @@ func storeOrFlush(audit asyncAudit) {
 			// to prevent oom kills by shoving too much input into one line
 			// we flush after the amount of strokes set in MaxStokesPerLine
 			if len(commandMap[audit.ctxid]) > MaxStokesPerLine {
-				logCommand(string(commandMap[audit.ctxid]), sessionMap[audit.ctxid].User, audit.ctxid, sessionMap[audit.ctxid].NameSpace, sessionMap[audit.ctxid].Pod, sessionMap[audit.ctxid].Container, sessionMap[audit.ctxid].ClientIP)
+				logCommand(string(commandMap[audit.ctxid]), audit.info.User, audit.ctxid, audit.info.NameSpace, audit.info.Pod, audit.info.Container, audit.info.ClientIP)
 				commandMap[audit.ctxid] = nil
 			}
 			commandMap[audit.ctxid] = append(commandMap[audit.ctxid], ascii)
@@ -48,5 +48,6 @@ func storeOrFlush(audit asyncAudit) {
 
 type asyncAudit struct {
 	ctxid string
+	info  sessionInfo
 	ascii []byte
 }

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -139,11 +139,11 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 
 	// tty exec audit keystrokes on tls conn see tcplogger
 	ctxid := uuid.New().String()
-	registerSession(ctxid, user, namespace, pod, container, clientIP)
+	info := registerSession(ctxid, user, namespace, pod, container, clientIP)
 	defer endSession(ctxid)
 
 	logCommand(cmd, user, ctxid, namespace, pod, container, clientIP)
-	proxy.Transport = auditedAPIServerTransport(ctxid)
+	proxy.Transport = auditedAPIServerTransport(ctxid, info)
 	proxy.ServeHTTP(w, r)
 }
 

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -34,15 +34,15 @@ func apiServerTransport() *http.Transport {
 }
 
 // tty exec uses tls conn wrapped in tcplogger so we can audit keystrokes
-func auditedAPIServerTransport(sessionID string) *http.Transport {
+func auditedAPIServerTransport(sessionID string, info sessionInfo) *http.Transport {
 	tr := baseAPIServerTransport()
 	tr.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return dialAuditedConn(ctx, sessionID)
+		return dialAuditedConn(ctx, sessionID, info)
 	}
 	return tr
 }
 
-func dialAuditedConn(ctx context.Context, sessionID string) (net.Conn, error) {
+func dialAuditedConn(ctx context.Context, sessionID string, info sessionInfo) (net.Conn, error) {
 	raw, err := (&net.Dialer{}).DialContext(ctx, "tcp", apiServerDial)
 	if err != nil {
 		return nil, err
@@ -52,16 +52,18 @@ func dialAuditedConn(ctx context.Context, sessionID string) (net.Conn, error) {
 		raw.Close()
 		return nil, err
 	}
-	return &TCPLogger{Conn: tlsConn, ctxid: sessionID}, nil
+	return &TCPLogger{Conn: tlsConn, ctxid: sessionID, info: info}, nil
 }
 
-func registerSession(ctxid, user, namespace, pod, container, clientIP string) {
-	mapSync.Lock()
-	sessionMap[ctxid] = sessionInfo{
+func registerSession(ctxid, user, namespace, pod, container, clientIP string) sessionInfo {
+	info := sessionInfo{
 		User: user, NameSpace: namespace, Pod: pod, Container: container, ClientIP: clientIP,
 	}
+	mapSync.Lock()
+	sessionMap[ctxid] = info
 	mapSync.Unlock()
 	logSessionEvent("session_start", user, ctxid, namespace, pod, container, clientIP)
+	return info
 }
 
 func endSession(ctxid string) {
@@ -84,6 +86,7 @@ func endSession(ctxid string) {
 type TCPLogger struct {
 	net.Conn
 	ctxid string
+	info  sessionInfo
 }
 
 func (t *TCPLogger) Write(b []byte) (n int, err error) {
@@ -116,27 +119,23 @@ func (t *TCPLogger) auditClientFrame(frameBytes []byte) {
 		if auditLogger.GetLevel() == zerolog.TraceLevel {
 			t.logTraceStroke(parsed.Payload)
 		}
-		asyncAuditChan <- asyncAudit{ctxid: t.ctxid, ascii: parsed.Payload}
+		asyncAuditChan <- asyncAudit{ctxid: t.ctxid, info: t.info, ascii: parsed.Payload}
 	}
 }
 
 func (t *TCPLogger) logTraceStroke(payload []byte) {
-	info, ok := sessionMap[t.ctxid]
-	if !ok {
-		return
-	}
 	stroke, err := hex.DecodeString(fmt.Sprintf("%x", payload))
 	if err != nil {
 		SysLogger.Error().Err(err).Msg("failed to parse payload")
 		return
 	}
 	auditLogger.Trace().
-		Str("user", info.User).
+		Str("user", t.info.User).
 		Str("session", t.ctxid).
-		Str("namespace", info.NameSpace).
-		Str("pod", info.Pod).
-		Str("container", info.Container).
-		Str("client_ip", info.ClientIP).
+		Str("namespace", t.info.NameSpace).
+		Str("pod", t.info.Pod).
+		Str("container", t.info.Container).
+		Str("client_ip", t.info.ClientIP).
 		// tty payload has nul bytes strip for trace log
 		Str("stroke", strings.ReplaceAll(string(stroke), "\u0000", "")).
 		Msg("")

--- a/rexec/server/tcp_test.go
+++ b/rexec/server/tcp_test.go
@@ -35,7 +35,7 @@ func TestAPIServerTransportsDiffer(t *testing.T) {
 		t.Fatal("non-TTY transport must not set DialTLSContext")
 	}
 
-	audited := auditedAPIServerTransport("sess")
+	audited := auditedAPIServerTransport("sess", sessionInfo{})
 	if audited.DialTLSContext == nil {
 		t.Fatal("TTY transport must set DialTLSContext")
 	}
@@ -95,7 +95,14 @@ func TestTCPLoggerWriteAuditsCoalescedFrames(t *testing.T) {
 	t.Cleanup(func() { asyncAuditChan = oldChan })
 
 	asyncAuditChan = make(chan asyncAudit, 4)
-	logger := &TCPLogger{Conn: &stubConn{}, ctxid: "s1"}
+	wantInfo := sessionInfo{
+		User:      "alice",
+		NameSpace: "default",
+		Pod:       "shell",
+		Container: "app",
+		ClientIP:  "192.0.2.1",
+	}
+	logger := &TCPLogger{Conn: &stubConn{}, ctxid: "s1", info: wantInfo}
 
 	key := [4]byte{0x01, 0x02, 0x03, 0x04}
 	first := buildFrame(0x2, []byte("echo"), true, key)
@@ -109,6 +116,9 @@ func TestTCPLoggerWriteAuditsCoalescedFrames(t *testing.T) {
 	for _, w := range want {
 		select {
 		case got := <-asyncAuditChan:
+			if got.info != wantInfo {
+				t.Fatalf("audit session info = %+v, want %+v", got.info, wantInfo)
+			}
 			if string(got.ascii) != w {
 				t.Fatalf("audit payload = %q, want %q", got.ascii, w)
 			}
@@ -145,7 +155,7 @@ func TestAuditedDialTLSContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	tr := auditedAPIServerTransport("sess")
+	tr := auditedAPIServerTransport("sess", sessionInfo{})
 	_, err := tr.DialTLSContext(ctx, "tcp", "unused")
 	if err == nil {
 		t.Fatal("expected error when context is already cancelled")


### PR DESCRIPTION
## Summary

The TTY audit path reads `sessionMap` without always using the correct mutex, `mapSync`. `storeOrFlush()` reads the session metadata while holding `commandSync`, which protects a different map, and `logTraceStroke()` reads it without any lock. These reads can race with `registerSession()` and `endSession()`, which add and remove entries from `sessionMap`.

This MR removes the `sessionMap` reads from the keystroke audit path. The `sessionInfo` is created when the session is registered and passed through `auditedAPIServerTransport()` and `dialAuditedConn()` to `TCPLogger`. Each `asyncAudit` record also receives a copy of this session information, which is used by `storeOrFlush()` and `logTraceStroke()`.

After this change, `sessionMap` is only accessed by `registerSession()` and `endSession()`, both using `mapSync`. The audit records continue to include the correct user, namespace, pod, container, and client IP.

## Tested scenarios

The session information and existing audit behavior are covered by unit tests:

* Session information:
  - `TCPLogger.Write()` queues audit records with the captured `sessionInfo`.
  - Each queued record contains the expected user, namespace, pod, container, and client IP.
  - Combined WebSocket frames keep the same session information.
* Existing audit behavior:
  - Combined binary frames are parsed and queued separately.
  - Non-binary WebSocket frames are not queued for keystroke auditing.
  - Invalid frames are still forwarded when audit parsing fails.
  - Session cleanup can be called more than once safely.

## Unit Testing
```bash
[claudio@macbook:~/Projects/kubectl-rexec-fork]% go test -v -race ./...
?   	github.com/adyen/kubectl-rexec	[no test files]
=== RUN   TestParseFileSpec
=== RUN   TestParseFileSpec/local_file
=== RUN   TestParseFileSpec/pod_file
=== RUN   TestParseFileSpec/pod_with_namespace
=== RUN   TestParseFileSpec/path_with_colon
--- PASS: TestParseFileSpec (0.00s)
    --- PASS: TestParseFileSpec/local_file (0.00s)
    --- PASS: TestParseFileSpec/pod_file (0.00s)
    --- PASS: TestParseFileSpec/pod_with_namespace (0.00s)
    --- PASS: TestParseFileSpec/path_with_colon (0.00s)
=== RUN   TestValidateLocalDestination
=== RUN   TestValidateLocalDestination/existing_dir
=== RUN   TestValidateLocalDestination/existing_file
=== RUN   TestValidateLocalDestination/new_file_in_dir
=== RUN   TestValidateLocalDestination/parent_missing
--- PASS: TestValidateLocalDestination (0.00s)
    --- PASS: TestValidateLocalDestination/existing_dir (0.00s)
    --- PASS: TestValidateLocalDestination/existing_file (0.00s)
    --- PASS: TestValidateLocalDestination/new_file_in_dir (0.00s)
    --- PASS: TestValidateLocalDestination/parent_missing (0.00s)
=== RUN   TestExtractTarSingleFile
--- PASS: TestExtractTarSingleFile (0.00s)
=== RUN   TestExtractTarDirectory
--- PASS: TestExtractTarDirectory (0.00s)
=== RUN   TestExtractTarRenameDirectory
--- PASS: TestExtractTarRenameDirectory (0.00s)
=== RUN   TestExtractTarLinkTypesSkipped
=== RUN   TestExtractTarLinkTypesSkipped/symlink
=== RUN   TestExtractTarLinkTypesSkipped/hardlink
--- PASS: TestExtractTarLinkTypesSkipped (0.00s)
    --- PASS: TestExtractTarLinkTypesSkipped/symlink (0.00s)
    --- PASS: TestExtractTarLinkTypesSkipped/hardlink (0.00s)
=== RUN   TestExtractTarPathTraversal
--- PASS: TestExtractTarPathTraversal (0.00s)
=== RUN   TestExtractTarValidDoubleDotFileName
--- PASS: TestExtractTarValidDoubleDotFileName (0.00s)
=== RUN   TestExtractTarValidDoubleDotDirectoryName
--- PASS: TestExtractTarValidDoubleDotDirectoryName (0.00s)
=== RUN   TestRunWithArgsValidation
=== RUN   TestRunWithArgsValidation/upload_blocked
=== RUN   TestRunWithArgsValidation/pod_to_pod_blocked
=== RUN   TestRunWithArgsValidation/local_to_local
=== RUN   TestRunWithArgsValidation/empty_path
--- PASS: TestRunWithArgsValidation (0.00s)
    --- PASS: TestRunWithArgsValidation/upload_blocked (0.00s)
    --- PASS: TestRunWithArgsValidation/pod_to_pod_blocked (0.00s)
    --- PASS: TestRunWithArgsValidation/local_to_local (0.00s)
    --- PASS: TestRunWithArgsValidation/empty_path (0.00s)
=== RUN   TestValidateCopySpecs
=== RUN   TestValidateCopySpecs/valid
=== RUN   TestValidateCopySpecs/upload
=== RUN   TestValidateCopySpecs/pod_to_pod
=== RUN   TestValidateCopySpecs/empty_path
--- PASS: TestValidateCopySpecs (0.00s)
    --- PASS: TestValidateCopySpecs/valid (0.00s)
    --- PASS: TestValidateCopySpecs/upload (0.00s)
    --- PASS: TestValidateCopySpecs/pod_to_pod (0.00s)
    --- PASS: TestValidateCopySpecs/empty_path (0.00s)
=== RUN   TestComputeSafeTarget
=== RUN   TestComputeSafeTarget/normal_file
=== RUN   TestComputeSafeTarget/bad_path
=== RUN   TestComputeSafeTarget/absolute_path
=== RUN   TestComputeSafeTarget/double_dot
--- PASS: TestComputeSafeTarget (0.00s)
    --- PASS: TestComputeSafeTarget/normal_file (0.00s)
    --- PASS: TestComputeSafeTarget/bad_path (0.00s)
    --- PASS: TestComputeSafeTarget/absolute_path (0.00s)
    --- PASS: TestComputeSafeTarget/double_dot (0.00s)
=== RUN   TestProcessTarEntry
=== RUN   TestProcessTarEntry/regular_file
=== RUN   TestProcessTarEntry/directory
--- PASS: TestProcessTarEntry (0.00s)
    --- PASS: TestProcessTarEntry/regular_file (0.00s)
    --- PASS: TestProcessTarEntry/directory (0.00s)
=== RUN   TestProcessTarEntryUnsupportedTypes
=== RUN   TestProcessTarEntryUnsupportedTypes/block_device
=== RUN   TestProcessTarEntryUnsupportedTypes/char_device
=== RUN   TestProcessTarEntryUnsupportedTypes/fifo
--- PASS: TestProcessTarEntryUnsupportedTypes (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/block_device (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/char_device (0.00s)
    --- PASS: TestProcessTarEntryUnsupportedTypes/fifo (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/plugin	2.236s
?   	github.com/adyen/kubectl-rexec/rexec	[no test files]
=== RUN   TestInitAPIServer
--- PASS: TestInitAPIServer (0.00s)
=== RUN   TestInitAPIServerIPv6
--- PASS: TestInitAPIServerIPv6 (0.00s)
=== RUN   TestInitAPIServerDefaultDomain
--- PASS: TestInitAPIServerDefaultDomain (0.00s)
=== RUN   TestParseWebSocketFrame
=== RUN   TestParseWebSocketFrame/unmasked_text_frame
=== PAUSE TestParseWebSocketFrame/unmasked_text_frame
=== RUN   TestParseWebSocketFrame/masked_binary_frame
=== PAUSE TestParseWebSocketFrame/masked_binary_frame
=== RUN   TestParseWebSocketFrame/empty_payload
=== PAUSE TestParseWebSocketFrame/empty_payload
=== RUN   TestParseWebSocketFrame/extended_16-bit_length
=== PAUSE TestParseWebSocketFrame/extended_16-bit_length
=== RUN   TestParseWebSocketFrame/extended_64-bit_length
=== PAUSE TestParseWebSocketFrame/extended_64-bit_length
=== RUN   TestParseWebSocketFrame/too_short_for_header
=== PAUSE TestParseWebSocketFrame/too_short_for_header
=== RUN   TestParseWebSocketFrame/truncated_extended_16-bit_header
=== PAUSE TestParseWebSocketFrame/truncated_extended_16-bit_header
=== RUN   TestParseWebSocketFrame/truncated_masking_key
=== PAUSE TestParseWebSocketFrame/truncated_masking_key
=== RUN   TestParseWebSocketFrame/payload_shorter_than_declared
=== PAUSE TestParseWebSocketFrame/payload_shorter_than_declared
=== CONT  TestParseWebSocketFrame/empty_payload
=== CONT  TestParseWebSocketFrame/payload_shorter_than_declared
=== CONT  TestParseWebSocketFrame/truncated_masking_key
=== CONT  TestParseWebSocketFrame/masked_binary_frame
=== CONT  TestParseWebSocketFrame/extended_16-bit_length
=== CONT  TestParseWebSocketFrame/too_short_for_header
=== CONT  TestParseWebSocketFrame/truncated_extended_16-bit_header
=== CONT  TestParseWebSocketFrame/unmasked_text_frame
=== CONT  TestParseWebSocketFrame/extended_64-bit_length
--- PASS: TestParseWebSocketFrame (0.00s)
    --- PASS: TestParseWebSocketFrame/empty_payload (0.00s)
    --- PASS: TestParseWebSocketFrame/payload_shorter_than_declared (0.00s)
    --- PASS: TestParseWebSocketFrame/truncated_masking_key (0.00s)
    --- PASS: TestParseWebSocketFrame/masked_binary_frame (0.00s)
    --- PASS: TestParseWebSocketFrame/extended_16-bit_length (0.00s)
    --- PASS: TestParseWebSocketFrame/too_short_for_header (0.00s)
    --- PASS: TestParseWebSocketFrame/truncated_extended_16-bit_header (0.00s)
    --- PASS: TestParseWebSocketFrame/unmasked_text_frame (0.00s)
    --- PASS: TestParseWebSocketFrame/extended_64-bit_length (0.00s)
=== RUN   TestParseWebSocketFrameCoalesced
--- PASS: TestParseWebSocketFrameCoalesced (0.00s)
=== RUN   TestExecHandlerUnsupportedContentType
--- PASS: TestExecHandlerUnsupportedContentType (0.00s)
=== RUN   TestExecHandlerBadJSON
--- PASS: TestExecHandlerBadJSON (0.00s)
=== RUN   TestExecHandlerAllowsNonExecKinds
--- PASS: TestExecHandlerAllowsNonExecKinds (0.00s)
=== RUN   TestExecHandlerBypassedUser
--- PASS: TestExecHandlerBypassedUser (0.00s)
=== RUN   TestExecHandlerSecretSauce
--- PASS: TestExecHandlerSecretSauce (0.00s)
=== RUN   TestExecHandlerExecDenied
--- PASS: TestExecHandlerExecDenied (0.00s)
=== RUN   TestCanPassBypassUser
--- PASS: TestCanPassBypassUser (0.00s)
=== RUN   TestCanPassSecretSauceMatch
--- PASS: TestCanPassSecretSauceMatch (0.00s)
=== RUN   TestCanPassNoMatch
--- PASS: TestCanPassNoMatch (0.00s)
=== RUN   TestInitMissingCA
--- PASS: TestInitMissingCA (0.00s)
=== RUN   TestInitMissingToken
--- PASS: TestInitMissingToken (0.00s)
=== RUN   TestInitInvalidSecretSauce
--- PASS: TestInitInvalidSecretSauce (0.00s)
=== RUN   TestRexecHandlerRejectsWithoutFrontProxyCert
--- PASS: TestRexecHandlerRejectsWithoutFrontProxyCert (0.00s)
=== RUN   TestRexecHandlerRejectsDisallowedCN
--- PASS: TestRexecHandlerRejectsDisallowedCN (0.00s)
=== RUN   TestRexecHandlerMissingUser
--- PASS: TestRexecHandlerMissingUser (0.00s)
=== RUN   TestVerifiedFrontProxy
--- PASS: TestVerifiedFrontProxy (0.00s)
=== RUN   TestAPIServerTransportsDiffer
--- PASS: TestAPIServerTransportsDiffer (0.00s)
=== RUN   TestEndSessionIdempotent
{"level":"info","facility":"audit","event":"session_end","user":"bob","session":"gone","namespace":"","pod":"","container":"","client_ip":"","time":"2026-06-20T10:42:01+01:00"}
--- PASS: TestEndSessionIdempotent (0.00s)
=== RUN   TestTCPLoggerWriteSkipsNonBinaryOpcode
--- PASS: TestTCPLoggerWriteSkipsNonBinaryOpcode (0.00s)
=== RUN   TestTCPLoggerWriteAuditsCoalescedFrames
--- PASS: TestTCPLoggerWriteAuditsCoalescedFrames (0.00s)
=== RUN   TestTCPLoggerWriteStillForwardsOnParseError
--- PASS: TestTCPLoggerWriteStillForwardsOnParseError (0.00s)
=== RUN   TestAuditedDialTLSContextCancelled
--- PASS: TestAuditedDialTLSContextCancelled (0.00s)
PASS
ok  	github.com/adyen/kubectl-rexec/rexec/server	1.577s
[claudio@macbook:~/Projects/kubectl-rexec-fork]%
```

Feedback on the approach is welcome.