### PR TITLE
fix: unrecorded interactive shell

### DIFF
--- a/rexec/server/async.go
+++ b/rexec/server/async.go
@@ -28,7 +28,7 @@ func storeOrFlush(audit asyncAudit) {
 				commandMap[audit.ctxid] = commandMap[audit.ctxid][:len(commandMap[audit.ctxid])-1]
 			}
 			commandSync.Unlock()
-		case 13:
+		case 10, 13: // LF (non-tty line input) or CR (tty Enter)
 			commandSync.Lock()
 			logCommand(string(commandMap[audit.ctxid]), audit.info.User, audit.ctxid, audit.info.NameSpace, audit.info.Pod, audit.info.Container, audit.info.ClientIP)
 			commandMap[audit.ctxid] = nil

--- a/rexec/server/audit_test.go
+++ b/rexec/server/audit_test.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"bytes"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// TestParseParamsNeedsRecording covers which exec requests are flagged for
+// keystroke recording. The security-critical case is `kubectl exec -i` WITHOUT
+// `-t`: it streams interactive stdin (a shell, a REPL) that must be audited even
+// though no tty is allocated. Before the fix the decision keyed only on the tty
+// parameter, so a stdin-only session slipped through with the audited transport
+// disabled and only its initial command ("sh") logged, leaving an unaudited
+// interactive shell.
+func TestParseParamsNeedsRecording(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		wantRecording bool
+		wantContainer string
+	}{
+		{
+			name:          "tty session (-i -t) is recorded",
+			query:         "command=sh&container=app&stdin=true&stdout=true&stderr=true&tty=true",
+			wantRecording: true,
+			wantContainer: "app",
+		},
+		{
+			name:          "stdin-only session (-i, no -t) is recorded",
+			query:         "command=sh&container=app&stdin=true&stdout=true&stderr=true",
+			wantRecording: true,
+			wantContainer: "app",
+		},
+		{
+			name:          "true one-off (no stdin, no tty) is not recorded",
+			query:         "command=ls&container=app&stdout=true&stderr=true",
+			wantRecording: false,
+			wantContainer: "app",
+		},
+		{
+			name:          "explicit stdin=false is not recorded",
+			query:         "command=ls&stdin=false&stdout=true",
+			wantRecording: false,
+		},
+		{
+			name:          "explicit tty=false is not recorded",
+			query:         "command=ls&tty=false&stdout=true",
+			wantRecording: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatalf("parse query: %v", err)
+			}
+			_, needsRecording, container := parseParams(params)
+			if needsRecording != tt.wantRecording {
+				t.Fatalf("needsRecording = %v, want %v", needsRecording, tt.wantRecording)
+			}
+			if container != tt.wantContainer {
+				t.Fatalf("container = %q, want %q", container, tt.wantContainer)
+			}
+		})
+	}
+}
+
+// TestParseParamsMatchesKubectlWire encodes PodExecOptions exactly as the kubectl
+// client does and confirms a stdin-only exec (-i without -t) is flagged for
+// recording. This guards against drift in the wire format: the tty parameter is
+// omitted entirely when false (which is what originally enabled the bypass), so
+// recording must not depend on its presence.
+func TestParseParamsMatchesKubectlWire(t *testing.T) {
+	cases := []struct {
+		name          string
+		opts          corev1.PodExecOptions
+		wantRecording bool
+	}{
+		{
+			name:          "kubectl exec -i (stdin, no tty)",
+			opts:          corev1.PodExecOptions{Command: []string{"sh"}, Stdin: true, Stdout: true, Stderr: true},
+			wantRecording: true,
+		},
+		{
+			name:          "kubectl exec -i -t (stdin and tty)",
+			opts:          corev1.PodExecOptions{Command: []string{"sh"}, Stdin: true, Stdout: true, Stderr: true, TTY: true},
+			wantRecording: true,
+		},
+		{
+			name:          "kubectl exec (no stdin, no tty)",
+			opts:          corev1.PodExecOptions{Command: []string{"ls"}, Stdout: true, Stderr: true},
+			wantRecording: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			v, err := scheme.ParameterCodec.EncodeParameters(&opts, corev1.SchemeGroupVersion)
+			if err != nil {
+				t.Fatalf("encode params: %v", err)
+			}
+			_, needsRecording, _ := parseParams(v)
+			if needsRecording != tc.wantRecording {
+				t.Fatalf("needsRecording = %v, want %v (query=%q)", needsRecording, tc.wantRecording, v.Encode())
+			}
+		})
+	}
+}
+
+// captureAudit redirects the package audit logger to a buffer for assertions and
+// restores it when the test finishes.
+func captureAudit(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	old := auditLogger
+	buf := &bytes.Buffer{}
+	auditLogger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	t.Cleanup(func() { auditLogger = old })
+	return buf
+}
+
+// TestStoreOrFlushSplitsOnLineFeedAndCarriageReturn confirms that line input is
+// flushed as a command on both LF and CR. A raw-mode tty sends CR on Enter, but a
+// non-tty stdin session (now recorded after the bypass fix) sends LF. Without
+// handling LF, the keystrokes of an audited stdin-only shell would accumulate
+// instead of being segmented into auditable commands.
+func TestStoreOrFlushSplitsOnLineFeedAndCarriageReturn(t *testing.T) {
+	oldMap := commandMap
+	oldMax := MaxStokesPerLine
+	t.Cleanup(func() {
+		commandMap = oldMap
+		MaxStokesPerLine = oldMax
+	})
+	commandMap = map[string][]byte{}
+	MaxStokesPerLine = 2000
+
+	buf := captureAudit(t)
+
+	// "ls -la\n" and "whoami\r" exercise LF and CR respectively; the trailing LF
+	// after "exit" flushes the final command so the buffer ends empty.
+	storeOrFlush(asyncAudit{
+		ctxid: "sess-lf",
+		info:  sessionInfo{User: "alice", NameSpace: "default", Pod: "shell", Container: "app"},
+		ascii: []byte("ls -la\nwhoami\rexit\n"),
+	})
+
+	out := buf.String()
+	for _, want := range []string{"ls -la", "whoami", "exit"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected command %q in audit log, got: %s", want, out)
+		}
+	}
+	if got := commandMap["sess-lf"]; len(got) != 0 {
+		t.Fatalf("command buffer should be empty after trailing newline, got %q", got)
+	}
+}

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -352,21 +352,28 @@ func getIP(r *http.Request) string {
 	return clientIP
 }
 
-func parseParams(params url.Values) (command []string, ttyRequested bool, container string) {
+func parseParams(params url.Values) (command []string, needsRecording bool, container string) {
 	// first fetch the command parameters from the url params to check what commands were passed
 	// initially to the container
+	var ttyRequested, stdinRequested bool
 	for key, value := range params {
 		if key == "command" {
 			command = value
 		}
-		// we also check whether tty was requested, if so we will need to record the session
-		if key == "tty" {
+		// a tty session carries interactive keystrokes that must be audited
+		if key == "tty" && len(value) > 0 && value[0] == "true" {
 			ttyRequested = true
+		}
+		// stdin (kubectl exec -i) can drive an interactive interpreter such as
+		// sh/bash/python without a tty. Without recording it, the entire session
+		// would only be logged as its initial command, leaving an unaudited shell.
+		if key == "stdin" && len(value) > 0 && value[0] == "true" {
+			stdinRequested = true
 		}
 		// check for container param
 		if key == "container" && len(value) > 0 {
 			container = value[0]
 		}
 	}
-	return command, ttyRequested, container
+	return command, ttyRequested || stdinRequested, container
 }


### PR DESCRIPTION
The recording decision keyed solely on the `tty` query parameter, but the kube parameter codec omits `tty` entirely when false. As a result `kubectl rexec exec pod -i -- sh` (stdin, no tty) took the unaudited transport and only logged its initial command, yielding a fully interactive shell whose keystrokes were never recorded.

parseParams now flags a session for recording when stdin OR tty is requested, and matches on the parameter value ("true") rather than mere key presence so a literal `tty=false` no longer trips recording.

storeOrFlush now flushes a command on LF as well as CR: raw-mode ttys send CR on Enter, but non-tty stdin sessions send LF, so without this the keystrokes of a now-recorded stdin shell would never be segmented into auditable commands.

Adds tests covering the stdin-only recording decision and LF/CR command flushing.

