### PR TITLE
Add golangci lint and fix some linting warnings

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -30,7 +30,7 @@ jobs:
         run: go build -v ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           install-mode: goinstall
           version: latest

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -30,11 +30,11 @@ jobs:
         run: go build -v ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           install-mode: goinstall
           version: latest
-          args: --timeout=5m
+          args: --timeout=5m --disable=staticcheck
 
       - name: Run tests
         run: go test -json -v -race -count=1 ./... > TestResults-${{ matrix.go-version }}.json

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
+          install-mode: goinstall
           version: latest
           args: --timeout=5m
 

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+
       - name: Run tests
         run: go test -json -v -race -count=1 ./... > TestResults-${{ matrix.go-version }}.json
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+linters:
+  disable:
+    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,0 @@
-version: "2"
-
-linters:
-  disable:
-    - staticcheck

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -113,7 +113,9 @@ func Rexec() {
 	cmds.AddCommand(newExec)
 	cmds.AddCommand(NewCmdCp(f, kubectlOptions.IOStreams))
 
-	cmds.Execute()
+	if err := cmds.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 type RexecOptoins struct {

--- a/rexec/server/apiserver_test.go
+++ b/rexec/server/apiserver_test.go
@@ -50,9 +50,15 @@ func TestInitAPIServerDefaultDomain(t *testing.T) {
 	})
 
 	ClusterDomain = ""
-	os.Unsetenv("CLUSTER_DOMAIN")
-	os.Unsetenv("KUBERNETES_SERVICE_HOST")
-	os.Unsetenv("KUBERNETES_SERVICE_PORT")
+	if err := os.Unsetenv("CLUSTER_DOMAIN"); err != nil {
+		t.Fatalf("unset CLUSTER_DOMAIN: %v", err)
+	}
+	if err := os.Unsetenv("KUBERNETES_SERVICE_HOST"); err != nil {
+		t.Fatalf("unset KUBERNETES_SERVICE_HOST: %v", err)
+	}
+	if err := os.Unsetenv("KUBERNETES_SERVICE_PORT"); err != nil {
+		t.Fatalf("unset KUBERNETES_SERVICE_PORT: %v", err)
+	}
 	initAPIServer()
 
 	if apiServerHost != "kubernetes.default.svc.cluster.local" {

--- a/rexec/server/server.go
+++ b/rexec/server/server.go
@@ -26,7 +26,9 @@ func Server() {
 	// returning some dummy json making kubeapiserver happier
 	r.HandleFunc("/apis/audit.adyen.internal/v1beta1", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(httpSpec))
+		if _, err := w.Write([]byte(httpSpec)); err != nil {
+			SysLogger.Error().Err(err).Msg("failed to write response")
+		}
 	})
 	// handle native pod exec through a validating webhook
 	r.HandleFunc("/validate-exec", execHandler)
@@ -64,7 +66,9 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	if !verifiedFrontProxy(r) {
 		SysLogger.Error().Str("client_ip", getIP(r)).Msg("rejected exec request: missing or untrusted front-proxy client certificate")
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(httpForbidden))
+		if _, err := w.Write([]byte(httpForbidden)); err != nil {
+			SysLogger.Error().Err(err).Msg("failed to write unauthorized response")
+		}
 		return
 	}
 
@@ -77,7 +81,9 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	// if any of the minimal parameters are missing we should bail
 	if user == "" || namespace == "" || pod == "" {
 		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte(httpForbidden))
+		if _, err := w.Write([]byte(httpForbidden)); err != nil {
+			SysLogger.Error().Err(err).Msg("failed to write forbidden response")
+		}
 		return
 	}
 	r.Header.Add("Kubectl-Command", "kubectl exec")
@@ -87,7 +93,9 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		SysLogger.Error().Err(err).Msg("failed to check the service account token")
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(httpInternalError))
+		if _, err := w.Write([]byte(httpInternalError)); err != nil {
+			SysLogger.Error().Err(err).Msg("failed to write internal error response")
+		}
 		return
 	}
 	// adding the service account token we are using for impersonating
@@ -118,7 +126,9 @@ func rexecHandler(w http.ResponseWriter, r *http.Request) {
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(httpInternalError))
+		if _, err := w.Write([]byte(httpInternalError)); err != nil {
+			SysLogger.Error().Err(err).Msg("failed to write internal error response")
+		}
 		return
 	}
 
@@ -224,7 +234,9 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(respBytes)
+	if _, err := w.Write(respBytes); err != nil {
+		SysLogger.Error().Err(err).Msg("failed to write admission response")
+	}
 }
 
 // canPass checks whether the exec request is allowed

--- a/rexec/server/server_test.go
+++ b/rexec/server/server_test.go
@@ -236,8 +236,12 @@ func TestInitMissingCA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tf.WriteString("token-123")
-	tf.Close()
+	if _, err := tf.WriteString("token-123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tf.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	caPath = "/invalid/ca.crt"
 	tokenPath = tf.Name()
@@ -261,7 +265,9 @@ func TestInitMissingToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cf.Close()
+	if err := cf.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	caPath = cf.Name()
 	tokenPath = "/invalid/token-123"
@@ -285,14 +291,20 @@ func TestInitInvalidSecretSauce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cf.Close()
+	if err := cf.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	tf, err := os.CreateTemp(dir, "token")
 	if err != nil {
 		t.Fatal(err)
 	}
-	tf.WriteString("token-123")
-	tf.Close()
+	if _, err := tf.WriteString("token-123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tf.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	caPath = cf.Name()
 	tokenPath = tf.Name()

--- a/rexec/server/tcp.go
+++ b/rexec/server/tcp.go
@@ -49,7 +49,9 @@ func dialAuditedConn(ctx context.Context, sessionID string, info sessionInfo) (n
 	}
 	tlsConn := tls.Client(raw, apiServerTLSConfig())
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
-		raw.Close()
+		if closeErr := raw.Close(); closeErr != nil {
+			SysLogger.Error().Err(closeErr).Msg("failed to close raw connection")
+		}
 		return nil, err
 	}
 	return &TCPLogger{Conn: tlsConn, ctxid: sessionID, info: info}, nil


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This adds golangci-lint to the test suite. Also, added some error checks on places where the linter pointed out they were missing. Disabled one of the tests because it's more an annoyance than an actual problem.

## Tested scenarios
<!-- Description of tested scenarios -->

All tests pass, and the workflows seem to run fine on my fork:
https://github.com/coredump/kubectl-rexec/actions/runs/29367581634/job/87202842455

