### PR TITLE
Adds action for smoke testing using kind

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      GO_VERSION: "1.26.4"
+      GO_VERSION: "1.26.5"
       KIND_VERSION: "v0.31.0"
       KIND_NODE_IMAGE: "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
       REXEC_CLUSTER_NAME: "rexec-e2e"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,8 @@ jobs:
           set -euo pipefail
           curl -fsSL -o kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           curl -fsSL -o kind.sha256sum "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum"
-          echo "$(cat kind.sha256sum)  kind" | sha256sum --check
+          expected_sha="$(awk '{print $1}' kind.sha256sum)"
+          echo "${expected_sha}  kind" | sha256sum --check
           install -m 0755 kind "${HOME}/kind"
           echo "${HOME}" >> "${GITHUB_PATH}"
           kind version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,83 @@
+name: E2E tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GO_VERSION: "1.26.4"
+      KIND_VERSION: "v0.31.0"
+      KIND_NODE_IMAGE: "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
+      REXEC_CLUSTER_NAME: "rexec-e2e"
+      REXEC_NODE_IMAGE: "kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install kind
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
+          curl -fsSL -o kind.sha256sum "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          echo "$(cat kind.sha256sum)  kind" | sha256sum --check
+          install -m 0755 kind "${HOME}/kind"
+          echo "${HOME}" >> "${GITHUB_PATH}"
+          kind version
+
+      - name: Ensure kubectl is installed
+        run: |
+          set -euo pipefail
+          if command -v kubectl >/dev/null 2>&1; then
+            kubectl version --client
+            exit 0
+          fi
+          curl -fsSL -o kubectl "https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl"
+          curl -fsSL -o kubectl.sha256 "https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+          install -m 0755 kubectl "${HOME}/kubectl"
+          echo "${HOME}" >> "${GITHUB_PATH}"
+          kubectl version --client
+
+      - name: Run e2e smoke checks
+        run: |
+          chmod +x ./scripts/e2e.sh
+          ./scripts/e2e.sh
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          set -euo pipefail
+          mkdir -p e2e-artifacts
+          kubectl --context "kind-${REXEC_CLUSTER_NAME}" get all -A > e2e-artifacts/get-all.txt || true
+          kubectl --context "kind-${REXEC_CLUSTER_NAME}" get events -A --sort-by=.lastTimestamp > e2e-artifacts/events.txt || true
+          kubectl --context "kind-${REXEC_CLUSTER_NAME}" describe deployment/rexec -n kube-system > e2e-artifacts/rexec-deploy.txt || true
+          kubectl --context "kind-${REXEC_CLUSTER_NAME}" get apiservice v1beta1.audit.adyen.internal -o yaml > e2e-artifacts/apiservice.yaml || true
+          kubectl --context "kind-${REXEC_CLUSTER_NAME}" logs -n kube-system -l app=rexec --tail=-1 > e2e-artifacts/rexec.log || true
+          kind export logs --name "${REXEC_CLUSTER_NAME}" e2e-artifacts/kind-logs || true
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-diagnostics
+          path: e2e-artifacts
+
+      - name: Cleanup kind cluster
+        if: always()
+        run: kind delete cluster --name "${REXEC_CLUSTER_NAME}" || true

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.26.4' ]
+        go-version: [ '1.26.5' ]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,5 +27,5 @@ jobs:
 
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '1.26.4'
+          go-version-input: '1.26.5'
           go-package: ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS builder
+FROM golang:1.26-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651 AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/adyen/kubectl-rexec
 LABEL org.opencontainers.image.description="Rexec proxy"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adyen/kubectl-rexec
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -24,10 +24,10 @@ require_command() {
 }
 
 cleanup() {
-  if [ -n "${TMP_PLUGIN_DIR}" ] && [ -d "${TMP_PLUGIN_DIR}" ]; then
+  if [[ -n "${TMP_PLUGIN_DIR}" ]] && [[ -d "${TMP_PLUGIN_DIR}" ]]; then
     rm -rf "${TMP_PLUGIN_DIR}"
   fi
-  if [ "${KEEP_CLUSTER}" != "true" ]; then
+  if [[ "${KEEP_CLUSTER}" != "true" ]]; then
     kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
   fi
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -91,7 +91,7 @@ kubectl --context "${KUBE_CONTEXT}" wait --for=condition=Ready "pod/${POD}" -n "
 
 token="rexec-$(date +%s)-${RANDOM}"
 echo "checking rexec exec..."
-exec_output="$(kubectl --context "${KUBE_CONTEXT}" rexec exec "${POD}" -n "${NAMESPACE}" -- echo "${token}")"
+exec_output="$(kubectl rexec --context "${KUBE_CONTEXT}" exec "${POD}" -n "${NAMESPACE}" -- echo "${token}")"
 if ! grep -q "${token}" <<<"${exec_output}"; then
   echo "error: expected token in rexec exec output" >&2
   exit 1
@@ -102,9 +102,9 @@ wait_for_log_token "${token}"
 
 echo "checking rexec cp download..."
 remote_file="/tmp/rexec-cp-${token}"
-kubectl --context "${KUBE_CONTEXT}" rexec exec "${POD}" -n "${NAMESPACE}" -- sh -c "printf '%s' '${token}' > '${remote_file}'"
+kubectl rexec --context "${KUBE_CONTEXT}" exec "${POD}" -n "${NAMESPACE}" -- sh -c "printf '%s' '${token}' > '${remote_file}'"
 tmp_dir="$(mktemp -d)"
-kubectl --context "${KUBE_CONTEXT}" rexec cp "${POD}:${remote_file}" "${tmp_dir}/" -n "${NAMESPACE}"
+kubectl rexec --context "${KUBE_CONTEXT}" cp "${POD}:${remote_file}" "${tmp_dir}/" -n "${NAMESPACE}"
 if ! grep -q "${token}" "${tmp_dir}/$(basename "${remote_file}")"; then
   echo "error: copied file does not contain expected token" >&2
   rm -rf "${tmp_dir}"
@@ -114,7 +114,7 @@ fi
 echo "checking rexec cp upload rejection..."
 upload_file="${tmp_dir}/upload-${token}"
 printf '%s' "${token}" > "${upload_file}"
-if upload_error="$(kubectl --context "${KUBE_CONTEXT}" rexec cp "${upload_file}" "${POD}:/tmp/upload-${token}" -n "${NAMESPACE}" 2>&1)"; then
+if upload_error="$(kubectl rexec --context "${KUBE_CONTEXT}" cp "${upload_file}" "${POD}:/tmp/upload-${token}" -n "${NAMESPACE}" 2>&1)"; then
   echo "error: upload to pod succeeded unexpectedly" >&2
   rm -rf "${tmp_dir}"
   exit 1

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CLUSTER_NAME="${REXEC_CLUSTER_NAME:-rexec-e2e}"
+KIND_NODE_IMAGE="${REXEC_NODE_IMAGE:-kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f}"
+REXEC_IMAGE="${REXEC_IMAGE:-kubectl-rexec:e2e}"
+TEST_IMAGE="${REXEC_TEST_IMAGE:-busybox:1.36.1}"
+NAMESPACE="${REXEC_NAMESPACE:-default}"
+POD="${REXEC_POD:-test-pod}"
+KEEP_CLUSTER="${REXEC_KEEP_CLUSTER:-false}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+TMP_PLUGIN_DIR=""
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "error: required command not found: ${cmd}" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  if [ -n "${TMP_PLUGIN_DIR}" ] && [ -d "${TMP_PLUGIN_DIR}" ]; then
+    rm -rf "${TMP_PLUGIN_DIR}"
+  fi
+  if [ "${KEEP_CLUSTER}" != "true" ]; then
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+wait_for_log_token() {
+  local token="$1"
+  for _ in $(seq 1 20); do
+    if kubectl --context "${KUBE_CONTEXT}" logs -n kube-system -l app=rexec --since=2m 2>&1 | grep -q "${token}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "error: token '${token}' not found in rexec logs" >&2
+  exit 1
+}
+
+echo "validating prerequisites..."
+require_command docker
+require_command kind
+require_command kubectl
+require_command go
+require_command sed
+
+echo "creating kind cluster..."
+kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+kind create cluster --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}" --wait 180s
+
+echo "building kubectl plugin..."
+TMP_PLUGIN_DIR="$(mktemp -d)"
+go build -o "${TMP_PLUGIN_DIR}/kubectl-rexec" "${REPO_ROOT}/main.go"
+export PATH="${TMP_PLUGIN_DIR}:${PATH}"
+kubectl rexec --help >/dev/null
+
+echo "building and loading images..."
+docker build -t "${REXEC_IMAGE}" -f "${REPO_ROOT}/Dockerfile" "${REPO_ROOT}"
+docker pull "${TEST_IMAGE}" >/dev/null
+kind load docker-image --name "${CLUSTER_NAME}" "${REXEC_IMAGE}" "${TEST_IMAGE}"
+
+echo "deploying rexec manifests..."
+tmp_manifest="$(mktemp)"
+kubectl kustomize "${REPO_ROOT}/manifests" > "${tmp_manifest}"
+sed -i.bak \
+  -e "s#ghcr.io/adyen/kubectl-rexec:latest#${REXEC_IMAGE}#g" \
+  -e "s#Always#IfNotPresent#g" \
+  "${tmp_manifest}"
+rm -f "${tmp_manifest}.bak"
+kubectl --context "${KUBE_CONTEXT}" apply -f "${tmp_manifest}"
+rm -f "${tmp_manifest}"
+
+echo "waiting for deployment and apiservice..."
+kubectl --context "${KUBE_CONTEXT}" rollout status deployment/rexec -n kube-system --timeout=180s
+kubectl --context "${KUBE_CONTEXT}" wait --for=condition=Available apiservice/v1beta1.audit.adyen.internal --timeout=180s
+
+echo "creating test pod..."
+if ! kubectl --context "${KUBE_CONTEXT}" get pod "${POD}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+  kubectl --context "${KUBE_CONTEXT}" run "${POD}" -n "${NAMESPACE}" --restart=Never --image "${TEST_IMAGE}" -- sleep infinity
+fi
+kubectl --context "${KUBE_CONTEXT}" wait --for=condition=Ready "pod/${POD}" -n "${NAMESPACE}" --timeout=180s
+
+token="rexec-$(date +%s)-${RANDOM}"
+echo "checking rexec exec..."
+exec_output="$(kubectl --context "${KUBE_CONTEXT}" rexec exec "${POD}" -n "${NAMESPACE}" -- echo "${token}")"
+if ! grep -q "${token}" <<<"${exec_output}"; then
+  echo "error: expected token in rexec exec output" >&2
+  exit 1
+fi
+
+echo "checking audit logs..."
+wait_for_log_token "${token}"
+
+echo "checking rexec cp download..."
+remote_file="/tmp/rexec-cp-${token}"
+kubectl --context "${KUBE_CONTEXT}" rexec exec "${POD}" -n "${NAMESPACE}" -- sh -c "printf '%s' '${token}' > '${remote_file}'"
+tmp_dir="$(mktemp -d)"
+kubectl --context "${KUBE_CONTEXT}" rexec cp "${POD}:${remote_file}" "${tmp_dir}/" -n "${NAMESPACE}"
+if ! grep -q "${token}" "${tmp_dir}/$(basename "${remote_file}")"; then
+  echo "error: copied file does not contain expected token" >&2
+  rm -rf "${tmp_dir}"
+  exit 1
+fi
+
+echo "checking rexec cp upload rejection..."
+upload_file="${tmp_dir}/upload-${token}"
+printf '%s' "${token}" > "${upload_file}"
+if upload_error="$(kubectl --context "${KUBE_CONTEXT}" rexec cp "${upload_file}" "${POD}:/tmp/upload-${token}" -n "${NAMESPACE}" 2>&1)"; then
+  echo "error: upload to pod succeeded unexpectedly" >&2
+  rm -rf "${tmp_dir}"
+  exit 1
+fi
+if ! grep -q "copying to pods is not supported" <<<"${upload_error}"; then
+  echo "error: unexpected upload rejection message: ${upload_error}" >&2
+  rm -rf "${tmp_dir}"
+  exit 1
+fi
+rm -rf "${tmp_dir}"
+
+echo "checking direct kubectl exec denial..."
+if direct_exec_output="$(kubectl --context "${KUBE_CONTEXT}" exec "${POD}" -n "${NAMESPACE}" -- echo denied 2>&1)"; then
+  echo "error: direct kubectl exec succeeded unexpectedly" >&2
+  exit 1
+fi
+if ! grep -q "cannot use exec directly, use rexec plugin instead" <<<"${direct_exec_output}"; then
+  echo "error: unexpected direct exec denial message: ${direct_exec_output}" >&2
+  exit 1
+fi
+
+echo "e2e smoke checks passed"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

This adds an _smoke test_ action to the workflows. Basically it does

* installs Kind
* installs kubectl
* builds kubectl-rexec from the commit
* installs it on the kind cluster
* tests if logging a random token via rexec works
* tests if copying a file from a pod works
* tests if copying a file TO a pod fails

This ensures that new code/build at least work for the basic stuff.


## Tested scenarios
<!-- Description of tested scenarios -->

See above. Example run is here: https://github.com/coredump/kubectl-rexec/actions/runs/29366606835/job/87199672649

